### PR TITLE
[#6] 「プロカメラマン」表記を体験価値フォーカスの表現に変更

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,11 +38,11 @@
     <section class="hero">
       <div class="container">
         <div class="hero-content">
-          <h1>体験に集中しながら、プロが写真撮影</h1>
+          <h1>体験に集中しながら、思い出を写真に残す</h1>
           <p class="hero-subtitle">予約不要で呼べる出張カメラマンサービス</p>
           <p>
             At
-            Ima（あっといま）は、子育て中のご家族が公園や観光地で過ごす時間を、写真撮影の心配なく楽しめるサービスです。スマホ一つでプロカメラマンを呼び、体験に集中しながら自然な家族写真を残せます。
+            Ima（あっといま）は、子育て中のご家族が公園や観光地で過ごす時間を、写真撮影の心配なく楽しめるサービスです。スマホ一つでカメラマンを呼び、体験に集中しながら自然な家族写真を残せます。
           </p>
           <div class="hero-buttons">
             <a href="#features" class="btn">サービスを知る</a>
@@ -126,7 +126,7 @@
             <div class="feature-icon"><i class="fas fa-heart"></i></div>
             <h3 class="feature-title">体験重視</h3>
             <p>
-              撮影はプロに任せて、家族全員で体験を楽しめます。カメラを意識せず、自然な表情を残せます。
+              撮影はお任せして、家族全員で体験を楽しめます。カメラを意識せず、自然な表情を残せます。
             </p>
             <div class="feature-image">
               <img
@@ -355,7 +355,7 @@
                   </div>
                   <div class="badge badge-2">
                     <i class="fas fa-camera-retro"></i>
-                    <span>プロ撮影</span>
+                    <span>丁寧撮影</span>
                   </div>
                 </div>
               </div>
@@ -390,7 +390,7 @@
                 </div>
                 <h3>スキルを活かして収入を得る</h3>
                 <p class="hero-subtitle">
-                  写真専門学校生や見習いカメラマンとして、実践的な経験を積みながら収入が得られます
+                  カメラマンとして活動しながら、実践的な経験を積み収入が得られます
                 </p>
 
                 <div class="hero-features-tab">


### PR DESCRIPTION
## 概要
closes #6

LP内の「プロカメラマン」「プロ品質」等の表記を見直し、体験価値にフォーカスした表現に変更。MVP段階のカメラマン供給体制（写真専門学校生・見習い）と矛盾しない表現に統一。

## 変更内容
- ヒーローh1: 「プロが写真撮影」→「思い出を写真に残す」
- ヒーロー説明文: 「プロカメラマンを呼び」→「カメラマンを呼び」
- features体験重視: 「撮影はプロに任せて」→「撮影はお任せして」
- ユーザータブバッジ: 「プロ撮影」→「丁寧撮影」
- カメラマンタブ説明: 「写真専門学校生や見習いカメラマンとして」→「カメラマンとして活動しながら」

## 対象ファイル
- `index.html`: 5箇所の「プロ」関連表記を修正

## 品質チェック結果
- [x] HTML 構文検証 PASS
- [x] リンク検証 PASS
- [x] レスポンシブ検証 PASS
- [x] アクセシビリティ検証 PASS
- [x] コミット規約準拠

## テスト
- `index.html` 内の「プロ」表記がゼロであることを確認（grep検証済み）
- 変更はテキストのみ、HTML構造・CSS・JSへの影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)