### PR TITLE
[#23] Meta ピクセルの設置（Instagram広告計測用）

### DIFF
--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -155,11 +155,11 @@
           <i class="fas fa-arrow-left"></i> トップページに戻る
         </a>
 
-        <div class="update-date">最終更新日：2026年3月25日</div>
+        <div class="update-date">最終更新日：2026年4月9日</div>
 
         <div class="privacy-header">
           <h1>プライバシーポリシー</h1>
-          <p class="last-updated">2026年03月25日 改訂・施行</p>
+          <p class="last-updated">2026年04月09日 改訂・施行</p>
         </div>
 
         <!-- ============ お客様から取得する情報 ============ -->
@@ -285,7 +285,8 @@
           <ul>
             <li>Cookie（クッキー）</li>
             <li>ウェブビーコン</li>
-            <li>アクセス解析ツール（Google Analytics等）</li>
+            <li>アクセス解析ツール（Google Analytics）</li>
+            <li>広告効果測定ツール（Meta Pixel）</li>
           </ul>
           <p>
             これらの技術を無効化したい場合は、ブラウザの設定から変更することが可能です。ただし、一部機能が制限される場合があります。
@@ -371,6 +372,7 @@
           <ul>
             <li>komoju株式会社（決済処理）：氏名・メールアドレス・決済情報を提供します。当社はお客様のクレジットカード情報を直接保持しません。</li>
             <li>Google LLC（アクセス解析：Google Analytics）：Cookie情報・行動履歴を提供します。詳細は<a href="https://policies.google.com/privacy" target="_blank" rel="noopener noreferrer">Googleのプライバシーポリシー</a>をご参照ください。</li>
+            <li>Meta Platforms, Inc.（広告効果測定：Meta Pixel）：Cookie情報・閲覧行動・端末情報を提供します。詳細は<a href="https://www.facebook.com/privacy/policy/" target="_blank" rel="noopener noreferrer">Metaのプライバシーポリシー</a>をご参照ください。</li>
           </ul>
           <p>委託先に対しては、当社と同等の安全管理措置を求め、適切な監督を行います。</p>
         </section>
@@ -423,6 +425,11 @@
               <th>版</th>
               <th>施行日</th>
               <th>概要</th>
+            </tr>
+            <tr>
+              <td>v1.2</td>
+              <td>2026年4月9日</td>
+              <td>Meta Pixel（広告効果測定）の使用およびMeta Platforms, Inc.への委託を追記</td>
             </tr>
             <tr>
               <td>v1.1</td>

--- a/trial/album-guide.html
+++ b/trial/album-guide.html
@@ -19,6 +19,23 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="album-guide.css" />
+    <!-- Meta Pixel Code -->
+    <script>
+    !function(f,b,e,v,n,t,s)
+    {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+    n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+    if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+    n.queue=[];t=b.createElement(e);t.async=!0;
+    t.src=v;s=b.getElementsByTagName(e)[0];
+    s.parentNode.insertBefore(t,s)}(window, document,'script',
+    'https://connect.facebook.net/en_US/fbevents.js');
+    fbq('init', '978053765178387');
+    fbq('track', 'PageView');
+    </script>
+    <noscript><img height="1" width="1" style="display:none"
+    src="https://www.facebook.com/tr?id=978053765178387&ev=PageView&noscript=1"
+    /></noscript>
+    <!-- End Meta Pixel Code -->
   </head>
   <body class="trial-page">
 

--- a/trial/album-guide.html
+++ b/trial/album-guide.html
@@ -32,12 +32,12 @@
     fbq('init', '978053765178387');
     fbq('track', 'PageView');
     </script>
-    <noscript><img height="1" width="1" style="display:none"
-    src="https://www.facebook.com/tr?id=978053765178387&ev=PageView&noscript=1"
-    /></noscript>
     <!-- End Meta Pixel Code -->
   </head>
   <body class="trial-page">
+    <noscript><img height="1" width="1" style="display:none" alt=""
+    src="https://www.facebook.com/tr?id=978053765178387&ev=PageView&noscript=1"
+    /></noscript>
 
     <!-- ヘッダー -->
     <header class="guide-header">

--- a/trial/index.html
+++ b/trial/index.html
@@ -28,6 +28,23 @@
       href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@300;400;500;700&display=swap"
       rel="stylesheet"
     />
+    <!-- Meta Pixel Code -->
+    <script>
+    !function(f,b,e,v,n,t,s)
+    {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+    n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+    if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+    n.queue=[];t=b.createElement(e);t.async=!0;
+    t.src=v;s=b.getElementsByTagName(e)[0];
+    s.parentNode.insertBefore(t,s)}(window, document,'script',
+    'https://connect.facebook.net/en_US/fbevents.js');
+    fbq('init', '978053765178387');
+    fbq('track', 'PageView');
+    </script>
+    <noscript><img height="1" width="1" style="display:none"
+    src="https://www.facebook.com/tr?id=978053765178387&ev=PageView&noscript=1"
+    /></noscript>
+    <!-- End Meta Pixel Code -->
   </head>
   <body class="trial-page">
 

--- a/trial/index.html
+++ b/trial/index.html
@@ -41,12 +41,12 @@
     fbq('init', '978053765178387');
     fbq('track', 'PageView');
     </script>
-    <noscript><img height="1" width="1" style="display:none"
-    src="https://www.facebook.com/tr?id=978053765178387&ev=PageView&noscript=1"
-    /></noscript>
     <!-- End Meta Pixel Code -->
   </head>
   <body class="trial-page">
+    <noscript><img height="1" width="1" style="display:none" alt=""
+    src="https://www.facebook.com/tr?id=978053765178387&ev=PageView&noscript=1"
+    /></noscript>
 
     <!-- ヒーロー -->
     <section class="trial-hero">


### PR DESCRIPTION
## Summary
- `trial/index.html` と `trial/album-guide.html` の `<head>` 内に Meta Pixel ベースコードを設置
- Pixel ID: `978053765178387`

## 変更ファイル
- `trial/index.html` — ベースコード追加
- `trial/album-guide.html` — ベースコード追加

## Test plan
- [ ] Meta広告マネージャーの「テストイベント」でPageViewイベントが送信されることを確認
- [ ] trial/index.html と trial/album-guide.html の両方で計測される

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)