### PR TITLE
[#25] キャンペーン決済方法の限定と開催日時の確定

### DIFF
--- a/legal-archive/terms-of-service-v2.0.html
+++ b/legal-archive/terms-of-service-v2.0.html
@@ -3,8 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>利用規約 | At Ima（あっといま）</title>
-    <link rel="stylesheet" href="css/style-amber.css" />
+    <title>利用規約（v2.0） | At Ima（あっといま）</title>
+    <link rel="stylesheet" href="../css/style-amber.css" />
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"
@@ -140,18 +140,18 @@
     <header>
       <div class="container header-container">
         <div class="logo">
-          <a href="index.html">
+          <a href="../index.html">
             <span class="logo-text">At Ima</span>
             <span class="logo-sub">あっといま</span>
           </a>
         </div>
         <nav class="nav-menu">
           <ul>
-            <li><a href="index.html#features">サービス</a></li>
-            <li><a href="index.html#how">使い方</a></li>
-            <li><a href="index.html#voices">利用者の声</a></li>
-            <li><a href="index.html#stakeholders">参加する</a></li>
-            <li><a href="index.html#faq">FAQ</a></li>
+            <li><a href="../index.html#features">サービス</a></li>
+            <li><a href="../index.html#how">使い方</a></li>
+            <li><a href="../index.html#voices">利用者の声</a></li>
+            <li><a href="../index.html#stakeholders">参加する</a></li>
+            <li><a href="../index.html#faq">FAQ</a></li>
           </ul>
         </nav>
         <button class="mobile-menu-btn" aria-expanded="false">
@@ -164,15 +164,20 @@
 
     <main>
       <div class="policy-container">
-        <a href="index.html" class="back-link">
+        <a href="../index.html" class="back-link">
           <i class="fas fa-arrow-left"></i> トップページに戻る
         </a>
 
-        <div class="update-date">最終更新日：2026年4月21日</div>
+        <div class="important-notice">
+          <h3>過去の版です</h3>
+          <p>この利用規約は v2.0（2026年3月25日施行）です。最新版は<a href="../terms-of-service.html">こちら</a>をご確認ください。</p>
+        </div>
+
+        <div class="update-date">最終更新日：2026年3月25日</div>
 
         <div class="terms-header">
-          <h1>利用規約</h1>
-          <p class="last-updated">2026年04月21日 改訂・施行</p>
+          <h1>利用規約（v2.0）</h1>
+          <p class="last-updated">2026年03月25日 改訂・施行</p>
         </div>
 
         <!-- ============ 第1条：定義 ============ -->
@@ -295,8 +300,10 @@
             <li>
               利用可能な決済手段は以下の通りとします：
               <ul>
-                <li>クレジットカード（Visa、Mastercard）</li>
-                <li>コンビニ決済</li>
+                <li>クレジットカード（Visa、Mastercard、JCB、American Express）</li>
+                <li>デビットカード</li>
+                <li>Apple Pay、Google Pay</li>
+                <li>PayPay、LINE Pay、楽天ペイ</li>
               </ul>
               <p>
                 決済処理はkomoju株式会社が提供する決済サービスを通じて行われます。利用可能な決済手段は変更される場合があります。
@@ -761,19 +768,14 @@
               <th>概要</th>
             </tr>
             <tr>
-              <td>v2.1</td>
-              <td>2026年4月21日</td>
-              <td>利用可能な決済手段をクレジットカード（Visa、Mastercard）およびコンビニ決済に限定</td>
-            </tr>
-            <tr>
               <td>v2.0</td>
               <td>2026年3月25日</td>
-              <td>写真データ購入・決済機能対応、免責条項改定、準拠法・管轄裁判所の追加 <a href="legal-archive/terms-of-service-v2.0.html">閲覧</a></td>
+              <td>写真データ購入・決済機能対応、免責条項改定、準拠法・管轄裁判所の追加</td>
             </tr>
             <tr>
               <td>v1.0</td>
               <td>2025年6月4日</td>
-              <td>制定 <a href="legal-archive/terms-of-service-v1.0.html">閲覧</a></td>
+              <td>制定 <a href="terms-of-service-v1.0.html">閲覧</a></td>
             </tr>
           </table>
         </section>
@@ -811,18 +813,18 @@
             <div class="footer-links-group">
               <h4>サービス</h4>
               <ul class="footer-links">
-                <li><a href="index.html#features">特徴</a></li>
-                <li><a href="index.html#how">使い方</a></li>
-                <li><a href="index.html#voices">利用者の声</a></li>
+                <li><a href="../index.html#features">特徴</a></li>
+                <li><a href="../index.html#how">使い方</a></li>
+                <li><a href="../index.html#voices">利用者の声</a></li>
               </ul>
             </div>
 
             <div class="footer-links-group">
               <h4>参加する</h4>
               <ul class="footer-links">
-                <li><a href="index.html#stakeholders">モニター応募</a></li>
-                <li><a href="index.html#stakeholders">カメラマン応募</a></li>
-                <li><a href="index.html#stakeholders">施設提携</a></li>
+                <li><a href="../index.html#stakeholders">モニター応募</a></li>
+                <li><a href="../index.html#stakeholders">カメラマン応募</a></li>
+                <li><a href="../index.html#stakeholders">施設提携</a></li>
               </ul>
             </div>
 
@@ -842,9 +844,9 @@
             Reserved.
           </p>
           <div class="footer-bottom-links">
-            <a href="privacy-policy.html">プライバシーポリシー</a>
-            <a href="terms-of-service.html">利用規約</a>
-            <a href="tokusho.html">特定商取引法に基づく表記</a>
+            <a href="../privacy-policy.html">プライバシーポリシー</a>
+            <a href="../terms-of-service.html">利用規約</a>
+            <a href="../tokusho.html">特定商取引法に基づく表記</a>
           </div>
         </div>
       </div>

--- a/legal-archive/terms-of-service-v2.0.html
+++ b/legal-archive/terms-of-service-v2.0.html
@@ -154,7 +154,7 @@
             <li><a href="../index.html#faq">FAQ</a></li>
           </ul>
         </nav>
-        <button class="mobile-menu-btn" aria-expanded="false">
+        <button class="mobile-menu-btn" aria-label="メニュー" aria-expanded="false">
           <span></span>
           <span></span>
           <span></span>

--- a/legal-archive/tokusho-v2.0.html
+++ b/legal-archive/tokusho-v2.0.html
@@ -152,7 +152,7 @@
             <li><a href="../index.html#faq">FAQ</a></li>
           </ul>
         </nav>
-        <button class="mobile-menu-btn" aria-expanded="false">
+        <button class="mobile-menu-btn" aria-label="メニュー" aria-expanded="false">
           <span></span>
           <span></span>
           <span></span>

--- a/legal-archive/tokusho-v2.0.html
+++ b/legal-archive/tokusho-v2.0.html
@@ -3,8 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>特定商取引法に基づく表記 | At Ima（あっといま）</title>
-    <link rel="stylesheet" href="css/style-amber.css" />
+    <title>特定商取引法に基づく表記（v2.0） | At Ima（あっといま）</title>
+    <link rel="stylesheet" href="../css/style-amber.css" />
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"
@@ -138,18 +138,18 @@
     <header>
       <div class="container header-container">
         <div class="logo">
-          <a href="index.html">
+          <a href="../index.html">
             <span class="logo-text">At Ima</span>
             <span class="logo-sub">あっといま</span>
           </a>
         </div>
         <nav class="nav-menu">
           <ul>
-            <li><a href="index.html#features">サービス</a></li>
-            <li><a href="index.html#how">使い方</a></li>
-            <li><a href="index.html#voices">利用者の声</a></li>
-            <li><a href="index.html#stakeholders">参加する</a></li>
-            <li><a href="index.html#faq">FAQ</a></li>
+            <li><a href="../index.html#features">サービス</a></li>
+            <li><a href="../index.html#how">使い方</a></li>
+            <li><a href="../index.html#voices">利用者の声</a></li>
+            <li><a href="../index.html#stakeholders">参加する</a></li>
+            <li><a href="../index.html#faq">FAQ</a></li>
           </ul>
         </nav>
         <button class="mobile-menu-btn" aria-expanded="false">
@@ -162,15 +162,20 @@
 
     <main>
       <div class="policy-container">
-        <a href="index.html" class="back-link">
+        <a href="../index.html" class="back-link">
           <i class="fas fa-arrow-left"></i> トップページに戻る
         </a>
 
-        <div class="update-date">最終更新日：2026年4月21日</div>
+        <div class="important-notice">
+          <h3>過去の版です</h3>
+          <p>この特定商取引法に基づく表記は v2.0（2026年3月25日施行）です。最新版は<a href="../tokusho.html">こちら</a>をご確認ください。</p>
+        </div>
+
+        <div class="update-date">最終更新日：2026年3月25日</div>
 
         <div class="tokusho-header">
-          <h1>特定商取引法に基づく表記</h1>
-          <p class="last-updated">2026年04月21日 改訂・施行</p>
+          <h1>特定商取引法に基づく表記（v2.0）</h1>
+          <p class="last-updated">2026年03月25日 改訂・施行</p>
         </div>
 
         <!-- ============ 事業者情報 ============ -->
@@ -262,7 +267,7 @@
             <tr>
               <th>支払方法</th>
               <td>
-                クレジットカード（Visa、Mastercard）、コンビニ決済<br>
+                クレジットカード（Visa、Mastercard、JCB、American Express）、デビットカード、Apple Pay、Google Pay、PayPay、LINE Pay、楽天ペイ<br>
                 ※決済処理はkomoju株式会社に委託しています
               </td>
             </tr>
@@ -326,8 +331,10 @@
             <tr>
               <th>支払方法</th>
               <td>
-                ・クレジットカード（Visa、Mastercard）<br>
-                ・コンビニ決済<br>
+                ・クレジットカード（Visa、Mastercard、JCB、American Express）<br>
+                ・デビットカード<br>
+                ・Apple Pay、Google Pay<br>
+                ・PayPay、LINE Pay、楽天ペイ<br>
                 ※決済処理はkomoju株式会社に委託しています。お客様の決済情報は当社では保持せず、komojuのセキュアな環境で管理されます。
               </td>
             </tr>
@@ -636,7 +643,7 @@
           <h2>個人情報の取扱い</h2>
           <p>
             当社のプライバシーポリシーに基づき、適切に管理いたします。<br>
-            詳細は<a href="privacy-policy.html">プライバシーポリシー</a>をご確認ください。
+            詳細は<a href="../privacy-policy.html">プライバシーポリシー</a>をご確認ください。
           </p>
           <h3>取得する個人情報</h3>
           <ul>
@@ -687,19 +694,14 @@
               <th>概要</th>
             </tr>
             <tr>
-              <td>v2.1</td>
-              <td>2026年4月21日</td>
-              <td>支払方法をクレジットカード（Visa、Mastercard）およびコンビニ決済に限定</td>
-            </tr>
-            <tr>
               <td>v2.0</td>
               <td>2026年3月25日</td>
-              <td>写真データ（デジタルコンテンツ）販売対応、返品特約追加、免責条項改定 <a href="legal-archive/tokusho-v2.0.html">閲覧</a></td>
+              <td>写真データ（デジタルコンテンツ）販売対応、返品特約追加、免責条項改定</td>
             </tr>
             <tr>
               <td>v1.0</td>
               <td>2025年6月4日</td>
-              <td>制定 <a href="legal-archive/tokusho-v1.0.html">閲覧</a></td>
+              <td>制定 <a href="tokusho-v1.0.html">閲覧</a></td>
             </tr>
           </table>
         </section>
@@ -724,18 +726,18 @@
             <div class="footer-links-group">
               <h4>サービス</h4>
               <ul class="footer-links">
-                <li><a href="index.html#features">特徴</a></li>
-                <li><a href="index.html#how">使い方</a></li>
-                <li><a href="index.html#voices">利用者の声</a></li>
+                <li><a href="../index.html#features">特徴</a></li>
+                <li><a href="../index.html#how">使い方</a></li>
+                <li><a href="../index.html#voices">利用者の声</a></li>
               </ul>
             </div>
 
             <div class="footer-links-group">
               <h4>参加する</h4>
               <ul class="footer-links">
-                <li><a href="index.html#stakeholders">モニター応募</a></li>
-                <li><a href="index.html#stakeholders">カメラマン応募</a></li>
-                <li><a href="index.html#stakeholders">施設提携</a></li>
+                <li><a href="../index.html#stakeholders">モニター応募</a></li>
+                <li><a href="../index.html#stakeholders">カメラマン応募</a></li>
+                <li><a href="../index.html#stakeholders">施設提携</a></li>
               </ul>
             </div>
 
@@ -755,9 +757,9 @@
             Reserved.
           </p>
           <div class="footer-bottom-links">
-            <a href="privacy-policy.html">プライバシーポリシー</a>
-            <a href="terms-of-service.html">利用規約</a>
-            <a href="tokusho.html">特定商取引法に基づく表記</a>
+            <a href="../privacy-policy.html">プライバシーポリシー</a>
+            <a href="../terms-of-service.html">利用規約</a>
+            <a href="../tokusho.html">特定商取引法に基づく表記</a>
           </div>
         </div>
       </div>

--- a/terms-of-service.html
+++ b/terms-of-service.html
@@ -154,7 +154,7 @@
             <li><a href="index.html#faq">FAQ</a></li>
           </ul>
         </nav>
-        <button class="mobile-menu-btn" aria-expanded="false">
+        <button class="mobile-menu-btn" aria-label="メニュー" aria-expanded="false">
           <span></span>
           <span></span>
           <span></span>

--- a/tokusho.html
+++ b/tokusho.html
@@ -152,7 +152,7 @@
             <li><a href="index.html#faq">FAQ</a></li>
           </ul>
         </nav>
-        <button class="mobile-menu-btn" aria-expanded="false">
+        <button class="mobile-menu-btn" aria-label="メニュー" aria-expanded="false">
           <span></span>
           <span></span>
           <span></span>

--- a/trial/album-guide.html
+++ b/trial/album-guide.html
@@ -100,7 +100,7 @@
               <i class="fas fa-credit-card" aria-hidden="true"></i>
             </div>
             <h3>クレジットカード</h3>
-            <p>Visa / Mastercard / JCB / AMEX / Diners / Discover</p>
+            <p>Visa / Mastercard</p>
           </div>
           <div class="guide-payment-item">
             <div class="guide-payment-icon">
@@ -108,13 +108,6 @@
             </div>
             <h3>コンビニ決済</h3>
             <p>ローソン / ファミリーマート / ミニストップ / セイコーマート / デイリーヤマザキ</p>
-          </div>
-          <div class="guide-payment-item">
-            <div class="guide-payment-icon">
-              <i class="fas fa-mobile-alt" aria-hidden="true"></i>
-            </div>
-            <h3>スマホ決済</h3>
-            <p>PayPay / 楽天ペイ</p>
           </div>
         </div>
       </div>

--- a/trial/index.html
+++ b/trial/index.html
@@ -91,7 +91,7 @@
           <div class="trial-event-detail">
             <div class="trial-event-row">
               <span class="trial-event-label"><i class="fas fa-calendar-alt" aria-hidden="true"></i> 日時</span>
-              <span class="trial-event-value">調整中（決まり次第お知らせします）</span>
+              <span class="trial-event-value">2026年4月25日（土）10:00〜16:00</span>
             </div>
             <div class="trial-event-row">
               <span class="trial-event-label"><i class="fas fa-map-marker-alt" aria-hidden="true"></i> 場所</span>
@@ -164,7 +164,7 @@
             </div>
           </div>
           <div class="trial-faq-item">
-            <h3 class="trial-faq-question" tabindex="0" role="button" aria-expanded="false">500円はなぜ安いの？</h3>
+            <h3 class="trial-faq-question" tabindex="0" role="button" aria-expanded="false">なぜ500円で購入できるのですか？</h3>
             <div class="trial-faq-answer">
               <p>サービス改善のためのモニター価格です。皆さまのフィードバックをもとにサービスを改善していくための特別料金となっています。</p>
             </div>

--- a/trial/index.html
+++ b/trial/index.html
@@ -236,7 +236,7 @@
     <!-- CTA -->
     <section class="trial-cta">
       <div class="container">
-        <h2>開催日はInstagramでお知らせします。</h2>
+        <h2>当日の最新情報はInstagramで。</h2>
         <p>お子さまの「今」をカメラマンが10分で残します。<br />予約なし・準備なしでOK。</p>
         <div class="trial-cta-buttons">
           <a href="https://www.instagram.com/at_ima_photo/" target="_blank" rel="noopener noreferrer" class="btn btn-secondary btn-large"><i class="fab fa-instagram" aria-hidden="true"></i> Instagramをフォローする</a>


### PR DESCRIPTION
## Summary
- キャンペーン（trial）の開催日時を **2026年4月25日（土）10:00〜16:00** に確定
- 決済方法を **クレジットカード（Visa / Mastercard）・コンビニ決済** の2種に限定
- 利用規約・特定商取引法に基づく表記を **v2.1** に改定（v2.0 は `legal-archive/` へ保存）
- FAQ 文言を自然な日本語に修正（「500円はなぜ安いの？」→「なぜ500円で購入できるのですか？」）

## 変更ファイル
| ファイル | 変更内容 |
|---|---|
| `trial/index.html` | 日時「調整中」→「2026年4月25日（土）10:00〜16:00」／ FAQ 文言修正 |
| `trial/album-guide.html` | 決済方法を Visa/Mastercard・コンビニのみに（スマホ決済・JCB/AMEX 等を削除） |
| `tokusho.html` | 支払方法を2箇所更新、改定履歴に v2.1 行を追加、施行日を 2026年4月21日 に更新 |
| `terms-of-service.html` | 第5条の決済手段を更新、改定履歴に v2.1 行を追加、施行日を 2026年4月21日 に更新 |
| `legal-archive/tokusho-v2.0.html` | 新規（過去版バナー付きでアーカイブ） |
| `legal-archive/terms-of-service-v2.0.html` | 新規（過去版バナー付きでアーカイブ） |

## 法的ページの改定（v2.0 → v2.1 マイナー改定）
- 施行日: **2026年4月21日**
- 変更理由: 実証フェーズにおける決済代行の運用コスト抑制のため、サポートする決済手段を段階的に限定
- `legal-rules.md` に従い、v2.0 をアーカイブ保存し改定履歴テーブルに追加

## Test plan
- [ ] ローカルで `trial/` にアクセスし、開催情報に「2026年4月25日（土）10:00〜16:00」が表示される
- [ ] `trial/album-guide.html` の決済方法が「クレジットカード（Visa/Mastercard）」「コンビニ決済」の2種のみ
- [ ] `tokusho.html` / `terms-of-service.html` の支払方法が Visa/Mastercard・コンビニに揃っている
- [ ] 改定履歴テーブルに v2.1 行が追加されている
- [ ] `legal-archive/tokusho-v2.0.html` / `terms-of-service-v2.0.html` が閲覧可能で、相対パス（CSS/ナビ/最新版リンク）が正しく機能する
- [ ] FAQ「なぜ500円で購入できるのですか？」のアコーディオンが動作する

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)