### PR TITLE
[#31] フッターSNSリンクの修正（Instagram/X設定、Facebook削除）

### DIFF
--- a/color-palette.html
+++ b/color-palette.html
@@ -7,7 +7,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@300;400;500;700&family=M+PLUS+Rounded+1c:wght@300;400;500;700&family=Zen+Maru+Gothic:wght@300;400;500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css">
     <style>
         /* ベーススタイル */
         body {

--- a/index.html
+++ b/index.html
@@ -620,14 +620,11 @@
                 子育て世代の新しい思い出作りをサポートします。日常の何気ない瞬間も、家族みんなで楽しみながら残せる、新しい写真体験を。
               </p>
               <div class="social-icons">
-                <a href="#" aria-label="Instagram"
+                <a href="https://www.instagram.com/at_ima_photo/" target="_blank" rel="noopener noreferrer" aria-label="Instagram"
                   ><i class="fab fa-instagram"></i
                 ></a>
-                <a href="#" aria-label="Twitter"
+                <a href="https://x.com/at_ima_photo" target="_blank" rel="noopener noreferrer" aria-label="X"
                   ><i class="fab fa-twitter"></i
-                ></a>
-                <a href="#" aria-label="Facebook"
-                  ><i class="fab fa-facebook"></i
                 ></a>
               </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="css/style-amber.css" />
     <link
       rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
     />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -624,7 +624,7 @@
                   ><i class="fab fa-instagram"></i
                 ></a>
                 <a href="https://x.com/at_ima_photo" target="_blank" rel="noopener noreferrer" aria-label="X"
-                  ><i class="fab fa-twitter"></i
+                  ><i class="fab fa-x-twitter"></i
                 ></a>
               </div>
             </div>

--- a/legal-archive/privacy-policy-v1.0.html
+++ b/legal-archive/privacy-policy-v1.0.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="../css/style-amber.css" />
     <link
       rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
     />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/legal-archive/terms-of-service-v1.0.html
+++ b/legal-archive/terms-of-service-v1.0.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="../css/style-amber.css" />
     <link
       rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
     />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/legal-archive/terms-of-service-v2.0.html
+++ b/legal-archive/terms-of-service-v2.0.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="../css/style-amber.css" />
     <link
       rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
     />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/legal-archive/tokusho-v1.0.html
+++ b/legal-archive/tokusho-v1.0.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="../css/style-amber.css" />
     <link
       rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
     />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/legal-archive/tokusho-v2.0.html
+++ b/legal-archive/tokusho-v2.0.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="../css/style-amber.css" />
     <link
       rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
     />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="css/style-amber.css" />
     <link
       rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
     />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/terms-of-service.html
+++ b/terms-of-service.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="css/style-amber.css" />
     <link
       rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
     />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/tokusho.html
+++ b/tokusho.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="css/style-amber.css" />
     <link
       rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
     />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/trial/album-guide.html
+++ b/trial/album-guide.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="style.css" />
     <link
       rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
     />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/trial/index.html
+++ b/trial/index.html
@@ -20,7 +20,7 @@
     <link rel="stylesheet" href="style.css" />
     <link
       rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
     />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />


### PR DESCRIPTION
## Summary
`index.html` フッターのSNSアイコンが全て `href="#"` プレースホルダーのままで機能していなかったため修正。あわせて Font Awesome を 6.5.2 にアップグレードし、正しい X ロゴを適用。

## 変更内容

### フッター SNS リンク修正（index.html）
| SNS | 変更内容 |
|---|---|
| Instagram | `href="#"` → `https://www.instagram.com/at_ima_photo/` |
| Twitter / X | `href="#"` → `https://x.com/at_ima_photo`、`aria-label` を「Twitter」→「X」、アイコン `fa-twitter` → `fa-x-twitter` |
| Facebook | アカウント未運用のためアイコンごと削除 |

外部リンクには `target="_blank"` + `rel="noopener noreferrer"` を付与。

### Font Awesome アップグレード（全12 HTML）
- `6.0.0` → `6.5.2`
- 対象: `index.html`, `tokusho.html`, `terms-of-service.html`, `privacy-policy.html`, `color-palette.html`, `trial/index.html`, `trial/album-guide.html`, `legal-archive/*.html`
- FA 6.x は後方互換のため既存アイコンは引き続き動作
- `fa-x-twitter` は 6.4.2 以降で利用可能

## Test plan
- [ ] フッターの Instagram アイコンをクリック → `at_ima_photo` の Instagram が別タブで開く
- [ ] フッターの X アイコンをクリック → `at_ima_photo` の X が別タブで開く（**Xロゴ表示**を確認）
- [ ] フッターに Facebook アイコンが表示されない
- [ ] 他のFAアイコン（カメラ、ハート、チェック等）が引き続き正常表示される

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)