### PR TITLE
[#28] trial/style.css の dead code 削除

### DIFF
--- a/trial/style.css
+++ b/trial/style.css
@@ -20,18 +20,8 @@
 
 .trial-hero h1,
 .trial-hero .trial-hero-lead,
-.trial-hero .trial-hero-note,
 .trial-hero .trial-hero-price {
   color: white;
-}
-
-.trial-hero .trial-hero-note {
-  font-size: 0.85rem;
-  opacity: 0.85;
-}
-
-.trial-hero .trial-hero-note strong {
-  color: #FFD9A0;
 }
 
 .trial-hero h1 {
@@ -41,51 +31,10 @@
   text-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
 }
 
-.trial-hero-badge {
-  display: inline-flex;
-  flex-direction: column;
-  align-items: center;
-  background-color: var(--trial-terracotta);
-  color: white;
-  border-radius: 50%;
-  width: 120px;
-  height: 120px;
-  justify-content: center;
-  margin-bottom: 24px;
-  box-shadow: 0 4px 20px rgba(212, 132, 90, 0.4);
-}
-
-.badge-price {
-  font-size: 2.2rem;
-  font-weight: 700;
-  line-height: 1;
-}
-
-.badge-price small {
-  font-size: 1rem;
-}
-
-.badge-label {
-  font-size: 0.75rem;
-  font-weight: 500;
-  margin-top: 2px;
-}
-
 .trial-hero-lead {
   font-size: clamp(1.1rem, 3vw, 1.4rem);
   line-height: 1.7;
   margin-bottom: 12px;
-}
-
-.trial-hero-note {
-  font-size: 0.95rem;
-  color: var(--color-text-muted);
-  margin-bottom: 28px;
-}
-
-.trial-hero-note strong {
-  color: var(--trial-terracotta);
-  font-size: 1.2rem;
 }
 
 .trial-hero-price {

--- a/trial/style.css
+++ b/trial/style.css
@@ -557,15 +557,6 @@
     padding: 60px 0 48px;
   }
 
-  .trial-hero-badge {
-    width: 100px;
-    height: 100px;
-  }
-
-  .badge-price {
-    font-size: 1.8rem;
-  }
-
   .trial-event-detail {
     padding: 24px 16px;
   }

--- a/trial/style.css
+++ b/trial/style.css
@@ -73,7 +73,6 @@
 
 .trial-hero-lead {
   font-size: clamp(1.1rem, 3vw, 1.4rem);
-  color: var(--color-text);
   line-height: 1.7;
   margin-bottom: 12px;
 }


### PR DESCRIPTION
## Summary
PR #30 マージ後に Copilot から追加指摘があった `trial/style.css` の dead code を削除。

## 経緯
PR #27（release）のレビューで Copilot から以下の指摘があった:

1. `.trial-hero-lead` の color 指定が重複（→ 実は詳細度的には問題なし、ただし dead code）
2. `.trial-hero-note` の color 指定が重複（→ そもそも HTML 未使用の完全 dead CSS）
3. `.trial-hero-badge` / `.badge-price` / `.badge-label` が HTML 未使用（dead CSS）

PR #30 にマージ前に追加コミットしたつもりが、既にマージ済み・branch closed 状態だったため取り残されていた。本PRで反映させる。

## 変更内容
- `.trial-hero-lead` の dead `color: var(--color-text)` 削除（1行）
- `.trial-hero-note` 関連定義を全削除（`.trial-hero .trial-hero-note`、`.trial-hero .trial-hero-note strong`、`.trial-hero-note`、`.trial-hero-note strong`）
- `.trial-hero-badge` / `.badge-price` / `.badge-price small` / `.badge-label` を削除
- 合計 **52行削減**

## HTML 参照の確認
以下のクラスは HTML から一切参照されていないことを grep で確認済み:
- `.trial-hero-note`
- `.trial-hero-badge`
- `.badge-price`
- `.badge-label`

## Test plan
- [ ] trial/ ページのヒーロー表示が変わらないこと（`.trial-hero-lead` は詳細度で白が維持）
- [ ] その他のページにも影響がないこと
- [ ] CSS サイズが減っている

Related: #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)