### PR TITLE
[#28] trial の og:url に末尾スラッシュを追加

### DIFF
--- a/trial/index.html
+++ b/trial/index.html
@@ -10,7 +10,7 @@
     <meta property="og:title" content="家族フォト撮影会 割引コードで500円 | At Ima" />
     <meta property="og:description" content="公園で10分、いつもの姿のまま家族写真。予約不要・カメラマンが撮影。アルバム価格2,200円が割引コードで500円。" />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://at-ima.com/trial" />
+    <meta property="og:url" content="https://at-ima.com/trial/" />
     <meta property="og:site_name" content="At Ima（あっといま）" />
     <meta property="og:image" content="https://at-ima.com/trial/ogp.png" />
     <meta property="og:image:width" content="1200" />


### PR DESCRIPTION
## Summary
`trial/index.html` の `og:url` が末尾スラッシュ無しになっていたのを、GitHub Pages の実URL（`https://at-ima.com/trial/`）に合わせて修正。

## 背景
SNSシェア時にURL正規化/重複扱いされる可能性があるため、公開URLと OGP メタタグの URL を揃える。Copilot レビュー指摘。

## 変更内容
```diff
- <meta property="og:url" content="https://at-ima.com/trial" />
+ <meta property="og:url" content="https://at-ima.com/trial/" />
```

Related: #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)