### PR TITLE
[#29] サイト全体のモバイルメニューを動作させる（CSS + JS null-check）

### DIFF
--- a/css/style-amber.css
+++ b/css/style-amber.css
@@ -1476,6 +1476,23 @@ footer::before {
     display: block;
   }
 
+  .nav-menu.active {
+    display: flex;
+    flex-direction: column;
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    background-color: var(--color-background);
+    padding: 20px;
+    box-shadow: 0 10px 15px rgba(0, 0, 0, 0.1);
+    z-index: 10;
+  }
+
+  .nav-menu.active a {
+    margin: 10px 0;
+  }
+
   .hero {
     min-height: auto;
     padding: 120px 0 80px;

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
           <a href="#stakeholders">参加する</a>
           <a href="#faq">FAQ</a>
         </nav>
-        <button class="mobile-menu-btn" aria-label="メニュー">
+        <button class="mobile-menu-btn" aria-label="メニュー" aria-expanded="false">
           <span></span>
         </button>
       </div>

--- a/js/main.js
+++ b/js/main.js
@@ -3,9 +3,10 @@
  */
 document.addEventListener("DOMContentLoaded", function () {
   // 現在の年を表示
-  document.getElementById("current-year").textContent = new Date()
-    .getFullYear()
-    .toString();
+  const currentYearEl = document.getElementById("current-year");
+  if (currentYearEl) {
+    currentYearEl.textContent = new Date().getFullYear().toString();
+  }
 
   // 画像の遅延読み込み対応
   if ("IntersectionObserver" in window) {

--- a/js/main.js
+++ b/js/main.js
@@ -58,7 +58,7 @@ document.addEventListener("DOMContentLoaded", function () {
   const mobileMenuBtn = document.querySelector(".mobile-menu-btn");
   const navMenu = document.querySelector(".nav-menu");
 
-  if (mobileMenuBtn) {
+  if (mobileMenuBtn && navMenu) {
     mobileMenuBtn.addEventListener("click", function () {
       this.classList.toggle("active");
       navMenu.classList.toggle("active");

--- a/js/main.js
+++ b/js/main.js
@@ -153,9 +153,10 @@ document.addEventListener("DOMContentLoaded", function () {
         });
 
         // モバイルメニューが開いていたら閉じる
-        if (navMenu.classList.contains("active")) {
+        if (navMenu && mobileMenuBtn && navMenu.classList.contains("active")) {
           navMenu.classList.remove("active");
           mobileMenuBtn.classList.remove("active");
+          mobileMenuBtn.setAttribute("aria-expanded", "false");
         }
       }
     });


### PR DESCRIPTION
## Summary
Issue #29 の必須対応を実装。`index.html` のモバイルメニューが実際に開閉できるようになります。

## 対応内容

### 必須項目（本PR）
- [x] `css/style-amber.css` に `.nav-menu.active` のモバイル表示ルールを追加
- [x] `js/main.js` の `#current-year` に null チェックを追加
- [x] `index.html` のモバイルメニュー動作を確認（ローカルで検証）

### 変更詳細

#### CSS（`@media (max-width: 768px)` 内）
```css
.nav-menu.active {
  display: flex;
  flex-direction: column;
  position: absolute;
  top: 100%;
  left: 0;
  right: 0;
  background-color: var(--color-background);
  padding: 20px;
  box-shadow: 0 10px 15px rgba(0, 0, 0, 0.1);
  z-index: 10;
}

.nav-menu.active a {
  margin: 10px 0;
}
```
`style-green.css:969-984` の既存パターンを踏襲。`header` が `position: fixed` なので、`.nav-menu.active` は `position: absolute; top: 100%` でヘッダー直下にドロップダウン表示される。

#### JavaScript
```diff
- document.getElementById("current-year").textContent = new Date().getFullYear().toString();
+ const currentYearEl = document.getElementById("current-year");
+ if (currentYearEl) {
+   currentYearEl.textContent = new Date().getFullYear().toString();
+ }
```
将来的に legal 系ページへ `main.js` を展開する際の安全性を確保。

## スコープ外（別Issueへの持ち越し）
Issue #29 の「任意」項目は本PRに含めず、必要に応じて別対応:
- legal 系ページで `.mobile-menu-btn` を復活させる（JS 読込 + `#current-year` 追加）
- `legal-archive/*-v1.0.html` の `.mobile-menu-btn` 削除

## Test plan
- [ ] モバイル幅（< 768px）で `index.html` のハンバーガーボタンを押すとメニューが開く
- [ ] もう一度押すと閉じる
- [ ] `aria-expanded` が開閉に応じて更新される
- [ ] キーボード操作（Enter/Space）でも動作する
- [ ] メニュー内リンクをクリックするとメニューが閉じる（main.js の既存ロジック）
- [ ] PC幅（>= 768px）では従来通り横並びで表示

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)