### PR TITLE
[#39] ご参加費用行の構造化と電子アルバム表記統一

### DIFF
--- a/trial/album-guide.html
+++ b/trial/album-guide.html
@@ -3,8 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>アルバム購入ガイド | At Ima</title>
-    <meta name="description" content="At Imaのアルバム購入方法をご案内します。撮影データの受け取りから決済、ダウンロードまでの流れを説明します。" />
+    <title>電子アルバム購入ガイド | At Ima</title>
+    <meta name="description" content="At Imaの電子アルバム購入方法をご案内します。撮影データの受け取りから決済、ダウンロードまでの流れを説明します。" />
 
     <link rel="stylesheet" href="../css/style-amber.css" />
     <link rel="stylesheet" href="style.css" />
@@ -26,7 +26,7 @@
     <header class="guide-header">
       <div class="container">
         <p class="guide-back"><a href="./">&larr; 撮影会ページに戻る</a></p>
-        <h1>アルバム購入ガイド</h1>
+        <h1>電子アルバム購入ガイド</h1>
         <p class="guide-lead">撮影データの受け取りから購入までの流れをご案内します。</p>
       </div>
     </header>
@@ -79,7 +79,7 @@
           <p class="guide-pricing-note">撮影会当日にお渡しする割引コードを<br />決済時に入力すると500円でご購入いただけます。</p>
           <ul class="guide-pricing-conditions">
             <li>有効期限: 撮影日から1ヶ月間</li>
-            <li>おひとり様1回まで（1アルバムにつき1コード）</li>
+            <li>おひとり様1回まで</li>
             <li>他の割引との併用不可</li>
             <li>第三者への譲渡不可</li>
             <li>コードを紛失された場合は <a href="mailto:info@atabiji.com">お問い合わせ</a>ください</li>

--- a/trial/index.html
+++ b/trial/index.html
@@ -4,11 +4,11 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>家族フォト撮影会 割引コードで500円 | At Ima</title>
-    <meta name="description" content="公園で10分、いつもの姿のまま家族写真。予約不要・カメラマンが撮影。アルバム価格2,200円が割引コードで500円。光が丘公園で開催。" />
+    <meta name="description" content="公園で10分、いつもの姿のまま家族写真。予約不要・カメラマンが撮影。電子アルバム価格2,200円が割引コードで500円。光が丘公園で開催。" />
 
     <!-- OGP -->
     <meta property="og:title" content="家族フォト撮影会 割引コードで500円 | At Ima" />
-    <meta property="og:description" content="公園で10分、いつもの姿のまま家族写真。予約不要・カメラマンが撮影。アルバム価格2,200円が割引コードで500円。" />
+    <meta property="og:description" content="公園で10分、いつもの姿のまま家族写真。予約不要・カメラマンが撮影。電子アルバム価格2,200円が割引コードで500円。" />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://at-ima.com/trial/" />
     <meta property="og:site_name" content="At Ima（あっといま）" />
@@ -74,7 +74,7 @@
               <i class="fas fa-images" aria-hidden="true"></i>
             </div>
             <h3>撮影データをお渡し</h3>
-            <p>撮影後3日以内にアプリへ写真が届きます。アルバムとして購入いただけます。<br /><a href="album-guide.html" class="trial-link-small">購入方法を見る &rarr;</a></p>
+            <p>撮影後3日以内にアプリへ写真が届きます。電子アルバムとして購入いただけます。<br /><a href="album-guide.html" class="trial-link-small">購入方法を見る &rarr;</a></p>
           </div>
         </div>
       </div>
@@ -97,9 +97,18 @@
               <span class="trial-event-label"><i class="fas fa-map-marker-alt" aria-hidden="true"></i> 場所</span>
               <span class="trial-event-value">光が丘公園 芝生広場（東京都練馬区）<br /><small>当日のカメラマンの居場所は<a href="https://www.instagram.com/at_ima_photo/" target="_blank" rel="noopener noreferrer" class="trial-instagram-link">Instagram</a>のストーリーズで随時お知らせ。わからない場合は<a href="https://www.instagram.com/at_ima_photo/" target="_blank" rel="noopener noreferrer" class="trial-instagram-link">DM</a>でお気軽にどうぞ。</small></span>
             </div>
-            <div class="trial-event-row">
-              <span class="trial-event-label"><i class="fas fa-yen-sign" aria-hidden="true"></i> 料金</span>
-              <span class="trial-event-value">アルバム価格 2,200円（税込）→ 割引コードで <strong class="trial-price-campaign">500円</strong><br /><small>※割引コードは撮影会当日にお渡しします <a href="album-guide.html" class="trial-link-small">購入方法を見る &rarr;</a></small></span>
+            <div class="trial-event-row trial-event-row-fee">
+              <span class="trial-event-label"><i class="fas fa-yen-sign" aria-hidden="true"></i> ご参加費用</span>
+              <span class="trial-event-value">
+                <span class="trial-fee-item">
+                  撮影参加：無料
+                  <small>開催時間内にお越しいただければ、カメラマンが撮影いたします</small>
+                </span>
+                <span class="trial-fee-item">
+                  電子アルバム購入（任意）：当日限定 <strong class="trial-price-campaign">500円</strong>（モニター価格）
+                  <small>撮影後3日以内にアプリでお届けいたします <a href="album-guide.html" class="trial-link-small">購入方法を見る &rarr;</a></small>
+                </span>
+              </span>
             </div>
           </div>
         </div>
@@ -132,7 +141,7 @@
           <div class="trial-flow-step">
             <div class="trial-flow-number">4</div>
             <h3>お渡し</h3>
-            <p>3日以内にアプリへ写真が届きます。アルバムとして購入できます</p>
+            <p>3日以内にアプリへ写真が届きます。電子アルバムとして購入できます</p>
           </div>
         </div>
       </div>
@@ -172,7 +181,7 @@
           <div class="trial-faq-item">
             <h3 class="trial-faq-question" tabindex="0" role="button" aria-expanded="false" aria-controls="trial-faq-answer-5">何枚くらい撮ってもらえますか？</h3>
             <div class="trial-faq-answer" id="trial-faq-answer-5" aria-hidden="true">
-              <p>10分の撮影でおよそ20〜40枚ほどお渡しする予定です。撮影後3日以内にアプリへ写真が届き、アルバムとして購入いただけます。（※枚数は目安です）</p>
+              <p>10分の撮影でおよそ20〜40枚ほどお渡しする予定です。撮影後3日以内にアプリへ写真が届き、電子アルバムとして購入いただけます。（※枚数は目安です）</p>
             </div>
           </div>
           <div class="trial-faq-item">

--- a/trial/index.html
+++ b/trial/index.html
@@ -105,7 +105,7 @@
                   <small>開催時間内にお越しいただければ、カメラマンが撮影いたします</small>
                 </span>
                 <span class="trial-fee-item">
-                  電子アルバム購入（任意）：当日限定 <strong class="trial-price-campaign">500円</strong>（モニター価格）
+                  電子アルバム購入（任意）：割引コード適用で <strong class="trial-price-campaign">500円</strong>（当日お渡し）
                   <small>撮影後3日以内にアプリでお届けいたします <a href="album-guide.html" class="trial-link-small">購入方法を見る &rarr;</a></small>
                 </span>
               </span>

--- a/trial/style.css
+++ b/trial/style.css
@@ -140,7 +140,7 @@
 
 .trial-event-label {
   flex-shrink: 0;
-  width: 90px;
+  width: 110px;
   font-size: 0.85rem;
   font-weight: 500;
   color: var(--color-text-muted);
@@ -172,6 +172,18 @@
 .trial-price-campaign {
   color: var(--trial-terracotta);
   font-size: 1.3rem;
+}
+
+.trial-event-row-fee {
+  align-items: flex-start;
+}
+
+.trial-fee-item {
+  display: block;
+}
+
+.trial-fee-item + .trial-fee-item {
+  margin-top: 10px;
 }
 
 /* 撮影の流れ */


### PR DESCRIPTION
## Summary
- trial/index.html 開催情報の「料金」行を「ご参加費用」に差し替え、**撮影参加（無料）** と **電子アルバム購入（任意・500円モニター価格）** の 2 項目に分割
- trial ページ全体で「アルバム」→「電子アルバム」に表記統一（購入/価格関連の 9 箇所）
- album-guide.html の割引コード条件から「（1アルバムにつき1コード）」を削除

Closes #39

## 変更内容

### 開催情報セクションの構造変更（trial/index.html）
**Before:**
\`\`\`
料金: アルバム価格 2,200円（税込）→ 割引コードで 500円
      ※割引コードは撮影会当日にお渡しします
\`\`\`

**After:**
\`\`\`
ご参加費用:
  撮影参加：無料
  開催時間内にお越しいただければ、カメラマンが撮影いたします

  電子アルバム購入（任意）：当日限定 500円（モニター価格）
  撮影後3日以内にアプリでお届けいたします [購入方法を見る →]
\`\`\`

### 電子アルバム表記統一（9 箇所）
- trial/index.html: meta description / og:description / 撮影の流れ / 開催情報 / FAQ（6 箇所）
- trial/album-guide.html: title / meta description / h1（3 箇所）
- アプリ内 UI 説明の「アルバム」は文脈から自明のため非変更

### CSS
- \`.trial-event-label\` 幅を 90px → 110px（「ご参加費用」が収まるよう）
- \`.trial-event-row-fee\` / \`.trial-fee-item\` を追加（日時/場所行と同じ視覚ウェイトを維持）

### その他
- 割引コード利用条件「（1アルバムにつき1コード）」を削除

## Test plan
- [x] \`/quality-gate\` PASS（HTML / リンク / a11y / コミット規約）
- [x] プレビューで 開催情報セクションのレイアウト崩れなしを確認
- [ ] レビュー時にモバイル（768px 以下）でのレスポンシブ確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)