### PR TITLE
[#42] GA4（Google Analytics）を全ページに設置

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,14 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-JM7YWZ5VDV"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-JM7YWZ5VDV');
+    </script>
     <title>At Ima（あっといま）| 予約不要で呼べる出張カメラマンサービス</title>
     <link rel="stylesheet" href="css/style-amber.css" />
     <link

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -3,6 +3,14 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-JM7YWZ5VDV"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-JM7YWZ5VDV');
+    </script>
     <title>プライバシーポリシー | At Ima（あっといま）</title>
     <link rel="stylesheet" href="css/style-amber.css" />
     <link

--- a/terms-of-service.html
+++ b/terms-of-service.html
@@ -3,6 +3,14 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-JM7YWZ5VDV"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-JM7YWZ5VDV');
+    </script>
     <title>利用規約 | At Ima（あっといま）</title>
     <link rel="stylesheet" href="css/style-amber.css" />
     <link

--- a/tokusho.html
+++ b/tokusho.html
@@ -3,6 +3,14 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-JM7YWZ5VDV"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-JM7YWZ5VDV');
+    </script>
     <title>特定商取引法に基づく表記 | At Ima（あっといま）</title>
     <link rel="stylesheet" href="css/style-amber.css" />
     <link

--- a/trial/album-guide.html
+++ b/trial/album-guide.html
@@ -3,6 +3,14 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-JM7YWZ5VDV"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-JM7YWZ5VDV');
+    </script>
     <title>電子アルバム購入ガイド | At Ima</title>
     <meta name="description" content="At Imaの電子アルバム購入方法をご案内します。撮影データの受け取りから決済、ダウンロードまでの流れを説明します。" />
 

--- a/trial/index.html
+++ b/trial/index.html
@@ -3,6 +3,14 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-JM7YWZ5VDV"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-JM7YWZ5VDV');
+    </script>
     <title>家族フォト撮影会 割引コードで500円 | At Ima</title>
     <meta name="description" content="公園で10分、いつもの姿のまま家族写真。予約不要・カメラマンが撮影。電子アルバム価格2,200円が割引コードで500円。光が丘公園で開催。" />
 


### PR DESCRIPTION
## Summary
- Meta 広告改善のためのアクセス解析として GA4（Google Analytics 4・無償版）のベースタグを at-ima.com の全アクティブ HTML 6 ファイルに設置
- 測定 ID: \`G-JM7YWZ5VDV\`
- 設置位置：\`<head>\` 冒頭、\`<meta charset>\` / \`<meta viewport>\` の直後（\`<title>\` の前）

Closes #42

## 変更ファイル（6 件）
| ファイル | 用途 |
|---|---|
| index.html | メイン LP |
| trial/index.html | 撮影会 LP（Meta 広告ランディング先） |
| trial/album-guide.html | 電子アルバム購入ガイド |
| privacy-policy.html | プライバシーポリシー |
| terms-of-service.html | 利用規約 |
| tokusho.html | 特定商取引法に基づく表記 |

## 設置対象外（意図的に除外）
- \`color-palette.html\`（内部用・開発リソース）
- \`legal-archive/*\`（過去版アーカイブ）

## 挿入コード
\`\`\`html
<!-- Google tag (gtag.js) -->
<script async src=\"https://www.googletagmanager.com/gtag/js?id=G-JM7YWZ5VDV\"></script>
<script>
  window.dataLayer = window.dataLayer || [];
  function gtag(){dataLayer.push(arguments);}
  gtag('js', new Date());
  gtag('config', 'G-JM7YWZ5VDV');
</script>
\`\`\`

## プライバシーポリシー対応
**改定不要**。develop 現行版（v1.1）に既に以下の記載あり：
- Cookie セクション: 「アクセス解析ツール（Google Analytics等）」
- 委託先セクション: 「Google LLC（アクセス解析：Google Analytics）：Cookie情報・行動履歴を提供します」

## 関連 Issue / PR
- 別途 #23（Meta Pixel）が \`feat/#23-meta-pixel\` ブランチで進行中。GA4 と Meta Pixel は独立した PR として進める。両者がマージされる順序により後発側で軽い rebase が発生する可能性あり

## Test plan
- [x] \`/quality-gate\` PASS（HTML / リンク / a11y / コミット規約）
- [x] 6 ファイルすべての \`<head>\` 冒頭に \`G-JM7YWZ5VDV\` の src と config が挿入されていることを確認
- [ ] develop マージ後、本番（at-ima.com）へリリース PR でデプロイ
- [ ] デプロイ後、GA4 リアルタイムレポートで自身のアクセスが計測されることを確認
- [ ] 拡張計測（スクロール／アウトバウンドクリック）がデフォルト ON で動作していることを確認
- [ ] UTM パラメータ付き URL が GA4「セッションの手動広告コンテンツ」で取得できることを確認

## 計画書
\`.temp/2026GW撮影会依頼/GA実装.txt\` の Step 2 に該当。Step 1（GA4 プロパティ作成）は完了済み。Step 3〜5（拡張計測確認 / コンバージョン設定 / レポート確認）は GA4 管理画面側で実施予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)