### PR TITLE
Release: GA4（Google Analytics）の全ページ設置

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,14 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-JM7YWZ5VDV"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-JM7YWZ5VDV');
+    </script>
     <title>At Ima（あっといま）| 予約不要で呼べる出張カメラマンサービス</title>
     <link rel="stylesheet" href="css/style-amber.css" />
     <link

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -3,6 +3,14 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-JM7YWZ5VDV"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-JM7YWZ5VDV');
+    </script>
     <title>プライバシーポリシー | At Ima（あっといま）</title>
     <link rel="stylesheet" href="css/style-amber.css" />
     <link

--- a/terms-of-service.html
+++ b/terms-of-service.html
@@ -3,6 +3,14 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-JM7YWZ5VDV"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-JM7YWZ5VDV');
+    </script>
     <title>利用規約 | At Ima（あっといま）</title>
     <link rel="stylesheet" href="css/style-amber.css" />
     <link

--- a/tokusho.html
+++ b/tokusho.html
@@ -3,6 +3,14 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-JM7YWZ5VDV"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-JM7YWZ5VDV');
+    </script>
     <title>特定商取引法に基づく表記 | At Ima（あっといま）</title>
     <link rel="stylesheet" href="css/style-amber.css" />
     <link

--- a/trial/album-guide.html
+++ b/trial/album-guide.html
@@ -3,6 +3,14 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-JM7YWZ5VDV"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-JM7YWZ5VDV');
+    </script>
     <title>電子アルバム購入ガイド | At Ima</title>
     <meta name="description" content="At Imaの電子アルバム購入方法をご案内します。撮影データの受け取りから決済、ダウンロードまでの流れを説明します。" />
 

--- a/trial/index.html
+++ b/trial/index.html
@@ -3,6 +3,14 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-JM7YWZ5VDV"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-JM7YWZ5VDV');
+    </script>
     <title>家族フォト撮影会 割引コードで500円 | At Ima</title>
     <meta name="description" content="公園で10分、いつもの姿のまま家族写真。予約不要・カメラマンが撮影。電子アルバム価格2,200円が割引コードで500円。光が丘公園で開催。" />
 


### PR DESCRIPTION
## Summary
- GA4（Google Analytics 4・無償版）のベースタグを at-ima.com の全アクティブ HTML 6 ファイルに設置
- 測定 ID: \`G-JM7YWZ5VDV\`
- Meta 広告改善のためのアクセス解析（滞在時間 / スクロール深度 / アプリ登録ボタンクリック等）を取得可能に

## 含まれる PR
- #43 (feat/#42-ga4-tracking) — Closes #42

## 変更ファイル（6 件）
- index.html
- trial/index.html
- trial/album-guide.html
- privacy-policy.html
- terms-of-service.html
- tokusho.html

## Test plan
- [x] \`/quality-gate\` PASS（develop マージ前）
- [x] develop マージ済（PR #43）
- [ ] マージ後 GitHub Pages 反映を https://at-ima.com/ で確認
- [ ] GA4 リアルタイムレポートで自身のアクセスが計測されることを確認
- [ ] GA4 拡張計測（スクロール / アウトバウンドクリック）が動作することを確認
- [ ] UTM パラメータ付き URL が GA4「セッションの手動広告コンテンツ」で取得できることを確認

## 後続タスク（GA4 管理画面側）
- Step 3: 拡張計測機能 ON 確認（デフォルト ON）
- Step 4: 「アプリ登録ボタンクリック」のコンバージョン設定
- Step 5: トラフィック獲得レポートの確認（5/1 以降）

🤖 Generated with [Claude Code](https://claude.com/claude-code)