### PR TITLE
docs: 撮影会スタッフ操作マニュアルページを追加

### DIFF
--- a/css/manual.css
+++ b/css/manual.css
@@ -1,0 +1,266 @@
+/* ==========================================================================
+   manual.css — 撮影会スタッフ操作マニュアル用スタイル
+   style-amber.css のトークン（--color-primary 等）を継承して使う。
+   実スクリーンショットは images/manual/ に置き、各 .shot-frame に流し込む。
+   注釈（囲み・ラベル）は CSS オーバーレイなので、画像を差し替えても崩れない。
+   ========================================================================== */
+
+:root {
+  --m-staff-fg: #9a5b07;
+  --m-staff-bg: #fcefd6;
+  --m-staff-line: #f1d9a8;
+  --m-user-fg: #0b6e86;
+  --m-user-bg: #e1f1f5;
+  --m-user-line: #bfe1e9;
+  --m-ok: #16794c;
+  --m-ok-bg: #e4f3ea;
+  --m-danger: #c02626;
+  --m-danger-bg: #fbebea;
+  --m-danger-line: #f2c9c6;
+  --m-card2: #f7f4f0;
+}
+
+.manual-main {
+  background:
+    radial-gradient(120% 60% at 100% 0%, rgba(var(--color-primary-rgb), 0.06), transparent 60%),
+    var(--color-background);
+}
+.manual-container {
+  max-width: 1000px;
+  margin: 0 auto;
+  padding: 40px 20px 80px;
+}
+.manual-container :is(h1, h2, h3, h4) { text-wrap: balance; }
+.tnum { font-variant-numeric: tabular-nums; }
+
+/* ---------- Breadcrumb ---------- */
+.manual-crumb {
+  font-size: 13px;
+  color: var(--color-text-muted);
+  margin-bottom: 20px;
+}
+.manual-crumb a { color: var(--color-text-muted); text-decoration: none; }
+.manual-crumb a:hover { color: var(--color-primary); text-decoration: underline; }
+
+/* ---------- Page hero ---------- */
+.manual-hero {
+  position: relative;
+  overflow: hidden;
+  border-radius: var(--border-radius-large);
+  border: 1px solid var(--color-border);
+  background:
+    radial-gradient(120% 140% at 100% 0%, rgba(var(--color-primary-rgb), 0.14), transparent 55%),
+    radial-gradient(120% 160% at 0% 100%, rgba(var(--color-accent-rgb), 0.10), transparent 50%),
+    #fff;
+  box-shadow: var(--box-shadow);
+  padding: 34px 34px 30px;
+}
+.manual-hero::before {
+  content: "";
+  position: absolute; left: 0; top: 0; bottom: 0; width: 6px;
+  background: linear-gradient(180deg, var(--color-primary), var(--color-accent));
+}
+.manual-kicker {
+  font-size: 12px; font-weight: 700; letter-spacing: 0.16em;
+  text-transform: uppercase; color: var(--color-secondary); margin: 0 0 10px;
+}
+.manual-hero h1 {
+  margin: 0; font-size: clamp(25px, 4vw, 38px); font-weight: 700; line-height: 1.25;
+}
+.manual-hero .lede {
+  margin: 14px 0 0; color: var(--color-text-muted); max-width: 62ch; font-size: 15.5px; line-height: 1.75;
+}
+.manual-meta { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 22px; }
+.manual-chip {
+  display: inline-flex; align-items: center; gap: 7px; font-size: 12.5px; font-weight: 500;
+  padding: 6px 12px; border-radius: 999px; background: var(--m-card2);
+  border: 1px solid var(--color-border); color: var(--color-text-muted);
+}
+.manual-chip b { color: var(--color-text); font-weight: 700; }
+.manual-chip .dot { width: 8px; height: 8px; border-radius: 50%; background: var(--color-primary); }
+
+.manual-legend {
+  margin-top: 18px; display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 12px;
+}
+.manual-legend .li {
+  display: flex; gap: 11px; align-items: flex-start; padding: 13px 15px;
+  background: #fff; border: 1px solid var(--color-border); border-radius: 12px;
+}
+.manual-legend .li p { margin: 3px 0 0; font-size: 13px; color: var(--color-text-muted); line-height: 1.6; }
+.manual-legend .li strong { font-size: 13.5px; }
+
+/* ---------- Role badges ---------- */
+.role {
+  flex: none; display: inline-flex; align-items: center; gap: 6px; font-weight: 700;
+  font-size: 12px; padding: 4px 10px; border-radius: 8px; white-space: nowrap;
+}
+.role.staff { color: var(--m-staff-fg); background: var(--m-staff-bg); border: 1px solid var(--m-staff-line); }
+.role.user  { color: var(--m-user-fg);  background: var(--m-user-bg);  border: 1px solid var(--m-user-line); }
+
+/* ---------- Section ---------- */
+.msection { margin-top: 52px; }
+.sec-head {
+  display: flex; gap: 18px; align-items: flex-start;
+  padding-bottom: 18px; border-bottom: 2px solid var(--color-border);
+}
+.sec-no {
+  flex: none; width: 56px; height: 56px; border-radius: 14px; display: grid; place-items: center;
+  font-size: 26px; font-weight: 800; color: #fff;
+  background: linear-gradient(150deg, var(--color-primary), var(--color-accent));
+  box-shadow: 0 6px 16px -8px rgba(var(--color-accent-rgb), 0.6);
+}
+.sec-head h2 { margin: 2px 0 0; font-size: 23px; font-weight: 700; }
+.sec-head .goal { margin: 6px 0 0; color: var(--color-text-muted); font-size: 14.5px; line-height: 1.7; }
+.sec-head .goal b { color: var(--color-secondary); }
+
+/* ---------- Steps ---------- */
+.steps { margin-top: 26px; display: flex; flex-direction: column; gap: 22px; }
+.step {
+  display: grid; grid-template-columns: 1fr 300px; gap: 26px; align-items: center;
+  background: #fff; border: 1px solid var(--color-border); border-radius: var(--border-radius-large);
+  padding: 24px 26px; box-shadow: var(--box-shadow);
+}
+.step-txt { min-width: 0; }
+.step-head { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; margin-bottom: 12px; }
+.step-num {
+  flex: none; width: 34px; height: 34px; border-radius: 50%; display: grid; place-items: center;
+  font-weight: 800; font-size: 15px; color: var(--color-secondary);
+  background: var(--m-staff-bg); border: 1.5px solid var(--m-staff-line);
+}
+.step-title { font-size: 17px; font-weight: 700; margin: 0; }
+.screen-tag {
+  font-size: 11.5px; font-weight: 700; color: var(--color-text-muted);
+  padding: 3px 9px; border-radius: 6px; background: var(--m-card2); border: 1px solid var(--color-border);
+}
+.step-txt p { margin: 0 0 9px; color: var(--color-text-muted); font-size: 14.5px; line-height: 1.75; }
+.step-txt p.lead { color: var(--color-text); font-size: 15px; font-weight: 600; }
+.step-txt ul { margin: 6px 0 0; padding-left: 18px; color: var(--color-text-muted); font-size: 14px; line-height: 1.7; }
+.step-txt ul li { margin: 3px 0; }
+.action {
+  display: flex; gap: 9px; align-items: flex-start; margin-top: 12px; padding: 11px 13px;
+  background: var(--m-staff-bg); border: 1px solid var(--m-staff-line); border-radius: 11px;
+  font-size: 13.5px; color: var(--color-text); line-height: 1.6;
+}
+.action .tap { font-weight: 800; color: var(--color-accent); white-space: nowrap; }
+.say {
+  margin-top: 10px; padding: 11px 14px; border-left: 3px solid var(--m-user-line);
+  background: var(--m-user-bg); border-radius: 0 10px 10px 0; font-size: 13.5px; color: var(--color-text); line-height: 1.6;
+}
+.say .lbl { display: block; font-size: 11px; font-weight: 700; letter-spacing: 0.08em; color: var(--m-user-fg); margin-bottom: 2px; }
+.say i { font-style: normal; }
+
+/* ---------- Screenshot slot (real capture + annotation overlay) ---------- */
+.shot { display: flex; flex-direction: column; align-items: center; gap: 9px; margin: 0; }
+.shot-frame {
+  position: relative; width: 264px; border-radius: 26px; padding: 10px;
+  background: linear-gradient(160deg, #2a2622, #100e0c);
+  box-shadow: 0 20px 40px -20px rgba(0, 0, 0, 0.5);
+}
+.shot-frame .inner {
+  position: relative; border-radius: 18px; overflow: hidden; background: #f5f5f4;
+  aspect-ratio: 390 / 844; /* iPhone 14: 撮影は 390x844 で統一 */
+}
+.shot-frame .inner img {
+  position: absolute; inset: 0; width: 100%; height: 100%; object-fit: cover; display: block;
+}
+/* 画像が未配置のときに見えるプレースホルダ（撮影ファイル名を表示） */
+.shot-ph {
+  position: absolute; inset: 0; display: flex; flex-direction: column; align-items: center;
+  justify-content: center; gap: 7px; text-align: center; padding: 18px;
+  color: #a79f95; background:
+    repeating-linear-gradient(45deg, #f0ece5, #f0ece5 10px, #eae5dc 10px, #eae5dc 20px);
+}
+.shot-ph i { font-size: 26px; opacity: 0.7; }
+.shot-ph b { font-size: 11px; color: #7c756c; word-break: break-all; font-weight: 700; }
+.shot-ph span { font-size: 11px; color: #a79f95; }
+
+/* 注釈: 囲み（--x,--y は中心%、--w,--h はサイズ%） */
+.anno { position: absolute; pointer-events: none; }
+.anno.ring {
+  left: var(--x); top: var(--y); width: var(--w); height: var(--h);
+  transform: translate(-50%, -50%);
+  border: 3px solid var(--color-accent); border-radius: 10px;
+  box-shadow: 0 0 0 3px rgba(var(--color-accent-rgb), 0.25);
+}
+.anno.tag {
+  left: var(--x); top: var(--y); transform: translate(-50%, -50%);
+  background: var(--color-accent); color: #fff; font-size: 11px; font-weight: 800;
+  padding: 3px 9px; border-radius: 999px; white-space: nowrap;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.25);
+}
+.shot figcaption { font-size: 12px; color: var(--color-text-muted); text-align: center; max-width: 270px; line-height: 1.55; }
+
+/* ---------- Flow strip ---------- */
+.flow {
+  display: flex; align-items: stretch; flex-wrap: wrap; margin: 24px 0 8px;
+  background: #fff; border: 1px solid var(--color-border); border-radius: var(--border-radius-large);
+  padding: 18px; box-shadow: var(--box-shadow);
+}
+.flow .fnode { flex: 1; min-width: 120px; text-align: center; padding: 6px 8px; }
+.flow .fnode .ic {
+  width: 42px; height: 42px; margin: 0 auto 8px; border-radius: 11px; display: grid; place-items: center;
+  font-size: 19px; color: var(--color-secondary); background: var(--m-staff-bg); border: 1px solid var(--m-staff-line);
+}
+.flow .fnode b { display: block; font-size: 13px; font-weight: 700; }
+.flow .fnode span { font-size: 11px; color: var(--color-text-muted); }
+.flow .arrow { display: flex; align-items: center; color: var(--color-primary); font-size: 18px; padding: 0 2px; }
+
+/* ---------- Device table ---------- */
+.devtable-wrap {
+  overflow-x: auto; margin-top: 18px; border: 1px solid var(--color-border);
+  border-radius: var(--border-radius-large); box-shadow: var(--box-shadow);
+}
+table.dev { border-collapse: collapse; width: 100%; min-width: 640px; background: #fff; font-size: 14px; }
+table.dev th, table.dev td { padding: 14px 16px; text-align: left; vertical-align: top; border-bottom: 1px solid var(--color-border); }
+table.dev thead th { background: var(--m-card2); font-size: 12.5px; }
+table.dev .os { display: inline-flex; align-items: center; gap: 8px; font-weight: 800; }
+table.dev .os .oi {
+  width: 26px; height: 26px; border-radius: 7px; display: grid; place-items: center; font-size: 13px;
+  color: var(--color-secondary); background: var(--m-staff-bg); border: 1px solid var(--m-staff-line);
+}
+table.dev tbody tr:last-child td { border-bottom: none; }
+table.dev .where { font-weight: 700; color: var(--color-text); }
+table.dev .how { color: var(--color-text-muted); font-size: 13px; margin-top: 3px; line-height: 1.55; }
+.pill {
+  display: inline-block; font-size: 11px; font-weight: 700; padding: 2px 8px; border-radius: 6px;
+  background: var(--m-card2); border: 1px solid var(--color-border); color: var(--color-text-muted); margin-top: 4px;
+}
+
+/* ---------- Notes ---------- */
+.note {
+  display: grid; grid-template-columns: auto 1fr; gap: 14px; align-items: start;
+  border-radius: var(--border-radius-large); padding: 18px 20px; margin-top: 20px; border: 1px solid;
+}
+.note .ni { width: 34px; height: 34px; border-radius: 9px; display: grid; place-items: center; font-size: 16px; flex: none; }
+.note h4 { margin: 0 0 5px; font-size: 15px; font-weight: 700; }
+.note p { margin: 0 0 6px; font-size: 13.5px; line-height: 1.7; color: var(--color-text); }
+.note ul { margin: 6px 0 0; padding-left: 18px; font-size: 13.5px; line-height: 1.7; }
+.note li { margin: 3px 0; }
+.note b { font-weight: 700; }
+.note.danger { background: var(--m-danger-bg); border-color: var(--m-danger-line); }
+.note.danger .ni { background: var(--m-danger); color: #fff; }
+.note.danger h4 { color: var(--m-danger); }
+.note.info { background: var(--m-card2); border-color: var(--color-border); }
+.note.info .ni { background: var(--m-staff-bg); border: 1px solid var(--m-staff-line); color: var(--color-secondary); }
+.note.tip { background: var(--m-ok-bg); border-color: transparent; }
+.note.tip .ni { background: var(--m-ok); color: #fff; }
+.note.tip h4 { color: var(--m-ok); }
+
+/* ---------- Responsive ---------- */
+@media (max-width: 760px) {
+  .step { grid-template-columns: 1fr; justify-items: center; }
+  .step-txt { width: 100%; }
+  .fig, .shot { order: -1; }
+  .flow .arrow { transform: rotate(90deg); }
+  .flow .fnode { flex-basis: 100%; }
+}
+
+/* ---------- Print ---------- */
+@media print {
+  header, footer, .manual-crumb { display: none !important; }
+  .manual-main { background: #fff; }
+  .manual-container { max-width: 100%; padding: 0; }
+  .msection, .step, .note, .flow, .devtable-wrap, .manual-hero { break-inside: avoid; box-shadow: none; }
+  .sec-head { break-after: avoid; }
+  .shot-frame { box-shadow: none; }
+}

--- a/images/manual/.gitkeep
+++ b/images/manual/.gitkeep
@@ -1,0 +1,4 @@
+# このディレクトリに撮影会マニュアル用のスクリーンショットを配置します。
+# ファイル名は manual.html の各 <img> と一致させてください（01-staff-home.png 〜 14-user-zip.png）。
+# 撮影サイズは iPhone 14 相当 390x844 で統一。
+# 自動撮影できる画面は ../../../atima-photo-share-mockup/atima-photo-share-mockup/scripts/manual-screenshots/ を参照。

--- a/manual.html
+++ b/manual.html
@@ -1,0 +1,548 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-JM7YWZ5VDV"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-JM7YWZ5VDV');
+    </script>
+    <title>撮影会 操作マニュアル（無料アルバム版）| At Ima（あっといま）</title>
+    <meta
+      name="description"
+      content="At Ima 撮影会当日の操作手順。受付（アルバム作成）／写真の格納・公開／写真ダウンロード（PC・iPhone・Android別の保存方法）を画面付きで解説します。"
+    />
+    <link rel="stylesheet" href="css/style-amber.css" />
+    <link rel="stylesheet" href="css/manual.css" />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@300;400;500;700&display=swap"
+      rel="stylesheet"
+    />
+    <!--
+      画面キャプチャは images/manual/ に配置してください（未配置の間はファイル名の
+      プレースホルダが表示されます）。撮影サイズは iPhone 14 相当 390x844 で統一。
+      ファイル名は scripts/manual-screenshots/ の撮影スクリプトの出力と一致します。
+    -->
+  </head>
+  <body>
+    <header>
+      <div class="container header-container">
+        <div class="logo">
+          <a href="index.html">
+            <span class="logo-text">At Ima</span>
+            <span class="logo-sub">あっといま</span>
+          </a>
+        </div>
+        <nav class="nav-menu">
+          <ul>
+            <li><a href="index.html#features">サービス</a></li>
+            <li><a href="index.html#how">使い方</a></li>
+            <li><a href="index.html#voices">利用者の声</a></li>
+            <li><a href="index.html#stakeholders">参加する</a></li>
+            <li><a href="index.html#faq">FAQ</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+
+    <main class="manual-main">
+      <div class="manual-container">
+        <nav class="manual-crumb" aria-label="パンくず">
+          <a href="index.html">ホーム</a> ／ 撮影会 操作マニュアル
+        </nav>
+
+        <!-- ============ HERO ============ -->
+        <section class="manual-hero">
+          <p class="manual-kicker">撮影会当日 オペレーションガイド</p>
+          <h1>撮影会 操作マニュアル ― 無料アルバム版 ―</h1>
+          <p class="lede">
+            受付でお客様のアルバムを作り、撮影した写真を格納・公開し、お客様がダウンロードするまで。当日の3つの流れを、実際の画面に沿って解説します。スタッフ・お客様ともに<b>スマホ／PCのブラウザ</b>で操作します。
+          </p>
+          <div class="manual-meta">
+            <span class="manual-chip"><span class="dot"></span>アプリ <b>At Ima</b></span>
+            <span class="manual-chip">スタッフ画面 <b>ブラウザ</b></span>
+            <span class="manual-chip">お客様画面 <b>スマホのブラウザ</b></span>
+            <span class="manual-chip">アルバム有効期限 <b>30日間</b></span>
+          </div>
+          <div class="manual-legend">
+            <div class="li">
+              <span class="role staff"><i class="fas fa-user"></i> スタッフ</span>
+              <div><strong>あなた（カメラマン・受付）</strong><p>スタッフ用アプリを操作する側。ホーム・QR・アルバム管理を行います。</p></div>
+            </div>
+            <div class="li">
+              <span class="role user"><i class="fas fa-mobile-screen"></i> お客様</span>
+              <div><strong>撮影されるお客様</strong><p>自分のスマホでQRを読み取り、アカウント登録〜ダウンロードを行います。</p></div>
+            </div>
+          </div>
+        </section>
+
+        <!-- ============ SECTION 1 ============ -->
+        <section class="msection">
+          <div class="sec-head">
+            <div class="sec-no">1</div>
+            <div>
+              <h2>受付（アルバム作成）／無料アルバム</h2>
+              <p class="goal">ゴール：QRでお客様と連携し、<b>お客様の端末にアルバムが表示される</b>ところまで確認する</p>
+            </div>
+          </div>
+
+          <div class="steps">
+            <!-- 1 -->
+            <article class="step">
+              <div class="step-txt">
+                <div class="step-head"><span class="step-num">1</span><h3 class="step-title">「無料アルバム」をONにする</h3><span class="screen-tag">スタッフ / ホーム</span></div>
+                <span class="role staff"><i class="fas fa-user"></i> スタッフ</span>
+                <p class="lead" style="margin-top:10px">ホーム画面で「無料アルバムとして受け付ける」を<b>ON</b>にします。</p>
+                <p>ONにするとボタンが「無料で撮影を受け付ける」に変わり、お客様は<b>購入なし</b>でダウンロードできるようになります。</p>
+                <div class="action"><span class="tap">操作 →</span><span>トグルをONにして「<b>無料で撮影を受け付ける</b>」をタップ</span></div>
+              </div>
+              <figure class="shot">
+                <div class="shot-frame"><div class="inner">
+                  <div class="shot-ph"><i class="fas fa-image"></i><b>01-staff-home.png</b><span>スタッフ / ホーム</span></div>
+                  <img src="images/manual/01-staff-home.png" alt="スタッフ ホーム画面：無料アルバムトグルON" loading="lazy" onerror="this.remove()" />
+                  <span class="anno ring" style="--x:50%;--y:53%;--w:84%;--h:11%"></span>
+                  <span class="anno tag" style="--x:50%;--y:42%">ここをON</span>
+                </div></div>
+                <figcaption>トグルON時はボタン文言が「無料で〜」に変わる</figcaption>
+              </figure>
+            </article>
+
+            <!-- 2 -->
+            <article class="step">
+              <div class="step-txt">
+                <div class="step-head"><span class="step-num">2</span><h3 class="step-title">QRコードをお客様に見せる</h3><span class="screen-tag">スタッフ / QR受付</span></div>
+                <span class="role staff"><i class="fas fa-user"></i> スタッフ</span>
+                <p class="lead" style="margin-top:10px">QR受付画面が開くので、この画面をお客様に向けて読み取ってもらいます。</p>
+                <p>お客様がスマホのカメラでQRを読み取ると、連絡先登録ページが開きます。</p>
+                <div class="say"><span class="lbl">お客様への声かけ例</span><i>「こちらのQRコードをスマホのカメラで読み取ってください」</i></div>
+                <div class="action"><span class="tap">補足</span><span>QRを読めない場合は「<b>QRなしで撮影に進む</b>」で手動作成も可能（顧客名は「未登録」）</span></div>
+              </div>
+              <figure class="shot">
+                <div class="shot-frame"><div class="inner">
+                  <div class="shot-ph"><i class="fas fa-image"></i><b>02-staff-qr.png</b><span>スタッフ / QR受付</span></div>
+                  <img src="images/manual/02-staff-qr.png" alt="スタッフ QR受付画面" loading="lazy" onerror="this.remove()" />
+                  <span class="anno ring" style="--x:50%;--y:38%;--w:52%;--h:24%"></span>
+                </div></div>
+                <figcaption>この画面をお客様のスマホで読み取ってもらう</figcaption>
+              </figure>
+            </article>
+
+            <!-- 3 -->
+            <article class="step">
+              <div class="step-txt">
+                <div class="step-head"><span class="step-num">3</span><h3 class="step-title">お客様がログイン／新規登録</h3><span class="screen-tag">お客様 / ログイン</span></div>
+                <span class="role user"><i class="fas fa-mobile-screen"></i> お客様</span>
+                <p class="lead" style="margin-top:10px">QRを読み取ると、お客様のスマホにログイン画面が開きます。</p>
+                <p><b>初めて使うお客様は新規登録</b>が必要です。Apple・Google・メールのいずれかで登録／ログインします。</p>
+                <div class="say"><span class="lbl">お客様への声かけ例</span><i>「初めての方はアカウントを作成してください。Apple・Google・メールのどれでもOKです」</i></div>
+              </div>
+              <figure class="shot">
+                <div class="shot-frame"><div class="inner">
+                  <div class="shot-ph"><i class="fas fa-image"></i><b>03-user-login.png</b><span>お客様 / ログイン</span></div>
+                  <img src="images/manual/03-user-login.png" alt="お客様 ログイン画面" loading="lazy" onerror="this.remove()" />
+                  <span class="anno ring" style="--x:50%;--y:88%;--w:84%;--h:7%"></span>
+                  <span class="anno tag" style="--x:50%;--y:79%">初回は新規登録</span>
+                </div></div>
+                <figcaption>初回は「新規登録」からアカウント作成</figcaption>
+              </figure>
+            </article>
+
+            <!-- 4 -->
+            <article class="step">
+              <div class="step-txt">
+                <div class="step-head"><span class="step-num">4</span><h3 class="step-title">お客様が「撮影を依頼する」</h3><span class="screen-tag">お客様 / 撮影依頼</span></div>
+                <span class="role user"><i class="fas fa-mobile-screen"></i> お客様</span>
+                <p class="lead" style="margin-top:10px">ログインすると撮影依頼画面が開き、名前・メールが自動入力されています。</p>
+                <p>内容を確認して「<b>撮影を依頼する</b>」をタップしてもらいます。</p>
+                <div class="action"><span class="tap">操作 →</span><span>お客様が「<b>撮影を依頼する</b>」をタップ</span></div>
+              </div>
+              <figure class="shot">
+                <div class="shot-frame"><div class="inner">
+                  <div class="shot-ph"><i class="fas fa-image"></i><b>04-user-request.png</b><span>お客様 / 撮影依頼</span></div>
+                  <img src="images/manual/04-user-request.png" alt="お客様 撮影依頼画面" loading="lazy" onerror="this.remove()" />
+                  <span class="anno ring" style="--x:50%;--y:88%;--w:84%;--h:7%"></span>
+                </div></div>
+                <figcaption>名前・メールは登録情報から自動入力</figcaption>
+              </figure>
+            </article>
+
+            <!-- 5 -->
+            <article class="step">
+              <div class="step-txt">
+                <div class="step-head"><span class="step-num">5</span><h3 class="step-title">依頼完了 → アルバム一覧へ</h3><span class="screen-tag">お客様 / 依頼完了</span></div>
+                <span class="role user"><i class="fas fa-mobile-screen"></i> お客様</span>
+                <p class="lead" style="margin-top:10px">「撮影依頼が完了しました」と表示されたら受付成功です。</p>
+                <p>お客様には「<b>アルバム一覧へ</b>」でホーム画面に進んでもらいます（後の手順7で使います）。</p>
+              </div>
+              <figure class="shot">
+                <div class="shot-frame"><div class="inner">
+                  <div class="shot-ph"><i class="fas fa-image"></i><b>05-user-request-done.png</b><span>お客様 / 依頼完了</span></div>
+                  <img src="images/manual/05-user-request-done.png" alt="お客様 撮影依頼完了画面" loading="lazy" onerror="this.remove()" />
+                  <span class="anno ring" style="--x:50%;--y:66%;--w:84%;--h:7%"></span>
+                </div></div>
+                <figcaption>この表示が出れば、スタッフ側にも通知される</figcaption>
+              </figure>
+            </article>
+
+            <!-- 6 -->
+            <article class="step">
+              <div class="step-txt">
+                <div class="step-head"><span class="step-num">6</span><h3 class="step-title">スタッフ画面が自動でアルバム詳細へ</h3><span class="screen-tag">スタッフ / アルバム詳細</span></div>
+                <span class="role staff"><i class="fas fa-user"></i> スタッフ</span>
+                <p class="lead" style="margin-top:10px">お客様が依頼すると、スタッフのQR画面が自動でアルバム詳細に切り替わります。</p>
+                <p>「○○様」のアルバムが自動作成され、<b>受付は完了</b>です。写真の追加はこの画面から行います（セクション2へ）。</p>
+              </div>
+              <figure class="shot">
+                <div class="shot-frame"><div class="inner">
+                  <div class="shot-ph"><i class="fas fa-image"></i><b>06-staff-album-empty.png</b><span>スタッフ / アルバム詳細</span></div>
+                  <img src="images/manual/06-staff-album-empty.png" alt="スタッフ アルバム詳細（写真なし）" loading="lazy" onerror="this.remove()" />
+                </div></div>
+                <figcaption>「○○様」のアルバムが自動で用意される</figcaption>
+              </figure>
+            </article>
+
+            <!-- 7 -->
+            <article class="step">
+              <div class="step-txt">
+                <div class="step-head"><span class="step-num">7</span><h3 class="step-title">お客様の端末でアルバム表示を確認【重要】</h3><span class="screen-tag">お客様 / ホーム</span></div>
+                <span class="role user"><i class="fas fa-mobile-screen"></i> お客様</span>
+                <p class="lead" style="margin-top:10px">最後に、お客様のホーム（アルバム一覧）で<b>画面を下に引っ張って更新</b>し、アルバムが出てくるかを一緒に確認します。</p>
+                <p>アルバムが表示されれば受付完了。まだ公開前なので「<b>公開までお待ちください</b>」と出ますが、これで正常です。</p>
+                <div class="say"><span class="lbl">お客様への声かけ例</span><i>「画面を上から下に指でスッと引っ張ってください。ご自身のアルバムが出てきたら受付完了です」</i></div>
+              </div>
+              <figure class="shot">
+                <div class="shot-frame"><div class="inner">
+                  <div class="shot-ph"><i class="fas fa-image"></i><b>07-user-home-refresh.png</b><span>お客様 / ホーム</span></div>
+                  <img src="images/manual/07-user-home-refresh.png" alt="お客様 ホーム（アルバム表示・公開までお待ちください）" loading="lazy" onerror="this.remove()" />
+                  <span class="anno ring" style="--x:50%;--y:40%;--w:88%;--h:22%"></span>
+                  <span class="anno tag" style="--x:50%;--y:13%">下に引っ張る</span>
+                </div></div>
+                <figcaption>下へ引っ張る＝更新。アルバムが出れば受付OK</figcaption>
+              </figure>
+            </article>
+          </div>
+
+          <div class="note danger">
+            <div class="ni"><i class="fas fa-triangle-exclamation"></i></div>
+            <div>
+              <h4>写真をアップロードする前に、必ず本人確認</h4>
+              <p>手順7で<b>お客様本人の画面にアルバムが表示されている</b>ことを確認してから、写真の追加に進んでください。</p>
+              <p style="margin:0">QRの受付は先着1名の仕組みのため、万一別の人が先に読み取ってしまうと、そのアルバムに紐づいてしまいます。「お客様本人の一覧にアルバムが出ているか」の確認が、取り違え・横取りを防ぐ最後の砦です。</p>
+            </div>
+          </div>
+        </section>
+
+        <!-- ============ SECTION 2 ============ -->
+        <section class="msection">
+          <div class="sec-head">
+            <div class="sec-no">2</div>
+            <div>
+              <h2>写真格納・アルバム公開</h2>
+              <p class="goal">ゴール：撮った写真を取り込み、見せる写真を選んで<b>公開＋お客様へメール通知</b>する（すべてスタッフ操作）</p>
+            </div>
+          </div>
+
+          <div class="steps">
+            <!-- 1 -->
+            <article class="step">
+              <div class="step-txt">
+                <div class="step-head"><span class="step-num">1</span><h3 class="step-title">写真を追加（アップロード）</h3><span class="screen-tag">スタッフ / アルバム詳細</span></div>
+                <span class="role staff"><i class="fas fa-user"></i> スタッフ</span>
+                <p class="lead" style="margin-top:10px">アルバム詳細の「＋ 写真を追加」から、端末内の写真を選んでアップロードします。</p>
+                <p><b>複数まとめて選択</b>できます。アップロード中は進捗（例：3 / 10）が表示されます。</p>
+                <div class="action"><span class="tap">操作 →</span><span>「<b>＋ 写真を追加</b>」→ 写真を複数選択</span></div>
+              </div>
+              <figure class="shot">
+                <div class="shot-frame"><div class="inner">
+                  <div class="shot-ph"><i class="fas fa-image"></i><b>08-staff-upload.png</b><span>スタッフ / アップロード</span></div>
+                  <img src="images/manual/08-staff-upload.png" alt="スタッフ 写真アップロード進捗" loading="lazy" onerror="this.remove()" />
+                  <span class="anno ring" style="--x:50%;--y:90%;--w:52%;--h:8%"></span>
+                </div></div>
+                <figcaption>複数選択でまとめてアップロードできる</figcaption>
+              </figure>
+            </article>
+
+            <!-- 2 -->
+            <article class="step">
+              <div class="step-txt">
+                <div class="step-head"><span class="step-num">2</span><h3 class="step-title">見せない写真は「保留」に分ける</h3><span class="screen-tag">スタッフ / 公開・保留</span></div>
+                <span class="role staff"><i class="fas fa-user"></i> スタッフ</span>
+                <p class="lead" style="margin-top:10px">「公開」タブ＝お客様に見える写真、「保留」タブ＝お客様に見えない写真です。</p>
+                <p>「選択」で写真を選び、<b>公開⇄保留</b>を切り替えます。写真をタップで拡大し、その場で削除も可能です。</p>
+                <div class="action"><span class="tap">ポイント</span><span><b>保留の写真はお客様には表示されません</b>。ボツ写真はここへ</span></div>
+              </div>
+              <figure class="shot">
+                <div class="shot-frame"><div class="inner">
+                  <div class="shot-ph"><i class="fas fa-image"></i><b>09-staff-hold.png</b><span>スタッフ / 公開・保留</span></div>
+                  <img src="images/manual/09-staff-hold.png" alt="スタッフ 公開・保留の選択モード" loading="lazy" onerror="this.remove()" />
+                  <span class="anno ring" style="--x:50%;--y:16%;--w:88%;--h:9%"></span>
+                </div></div>
+                <figcaption>選択 →「保留にする」でお客様の閲覧から外す</figcaption>
+              </figure>
+            </article>
+
+            <!-- 3 -->
+            <article class="step">
+              <div class="step-txt">
+                <div class="step-head"><span class="step-num">3</span><h3 class="step-title">公開してメールを送る</h3><span class="screen-tag">スタッフ / 公開ダイアログ</span></div>
+                <span class="role staff"><i class="fas fa-user"></i> スタッフ</span>
+                <p class="lead" style="margin-top:10px">写真がそろったら「公開して送信」。確認ダイアログで宛先・顧客名を確認します。</p>
+                <p><b>公開と同時にアルバムのURLがメールで届きます。</b>（メール未設定のお客様は公開のみで通知なし）</p>
+                <div class="action"><span class="tap">操作 →</span><span>「<b>公開して送信</b>」をタップ</span></div>
+              </div>
+              <figure class="shot">
+                <div class="shot-frame"><div class="inner">
+                  <div class="shot-ph"><i class="fas fa-image"></i><b>10-staff-publish.png</b><span>スタッフ / 公開ダイアログ</span></div>
+                  <img src="images/manual/10-staff-publish.png" alt="スタッフ 公開してメール送信ダイアログ" loading="lazy" onerror="this.remove()" />
+                  <span class="anno ring" style="--x:63%;--y:60%;--w:40%;--h:8%"></span>
+                </div></div>
+                <figcaption>宛先メールが正しいか確認してから送信</figcaption>
+              </figure>
+            </article>
+
+            <!-- 4 -->
+            <article class="step">
+              <div class="step-txt">
+                <div class="step-head"><span class="step-num">4</span><h3 class="step-title">公開完了（公開後も編集OK）</h3><span class="screen-tag">スタッフ / アルバム詳細</span></div>
+                <span class="role staff"><i class="fas fa-user"></i> スタッフ</span>
+                <p class="lead" style="margin-top:10px">ステータスが「公開中」になり、お客様がダウンロードできる状態になります。</p>
+                <p><b>公開後も</b>写真の追加・公開/保留の変更は可能です。取り下げたいときは「非公開にする」で戻せます。</p>
+              </div>
+              <figure class="shot">
+                <div class="shot-frame"><div class="inner">
+                  <div class="shot-ph"><i class="fas fa-image"></i><b>11-staff-published.png</b><span>スタッフ / 公開中</span></div>
+                  <img src="images/manual/11-staff-published.png" alt="スタッフ アルバム公開中" loading="lazy" onerror="this.remove()" />
+                  <span class="anno ring" style="--x:50%;--y:16%;--w:88%;--h:8%"></span>
+                </div></div>
+                <figcaption>「公開中」＝お客様がDL可能な状態</figcaption>
+              </figure>
+            </article>
+          </div>
+
+          <div class="note info">
+            <div class="ni"><i class="fas fa-envelope"></i></div>
+            <div>
+              <h4>お客様に届くもの</h4>
+              <p style="margin:0">公開すると、お客様のメールに<b>アルバムのURL</b>が届きます。お客様はそのリンク、またはアプリのホーム（アルバム一覧）からアルバムを開けます。写真を追加して再度公開しても、同じアルバムに反映されます。</p>
+            </div>
+          </div>
+        </section>
+
+        <!-- ============ SECTION 3 ============ -->
+        <section class="msection">
+          <div class="sec-head">
+            <div class="sec-no">3</div>
+            <div>
+              <h2>写真ダウンロード（端末別の保存方法）</h2>
+              <p class="goal">ゴール：お客様が写真を選んでダウンロードし、<b>PC・iPhone・Android それぞれで保存</b>できるよう案内する</p>
+            </div>
+          </div>
+
+          <div class="flow">
+            <div class="fnode"><div class="ic"><i class="fas fa-hand-point-up"></i></div><b>受付</b><span>アルバム作成</span></div>
+            <div class="arrow"><i class="fas fa-arrow-right"></i></div>
+            <div class="fnode"><div class="ic"><i class="fas fa-images"></i></div><b>格納・公開</b><span>写真を公開</span></div>
+            <div class="arrow"><i class="fas fa-arrow-right"></i></div>
+            <div class="fnode"><div class="ic"><i class="fas fa-envelope"></i></div><b>通知</b><span>メール／一覧に表示</span></div>
+            <div class="arrow"><i class="fas fa-arrow-right"></i></div>
+            <div class="fnode"><div class="ic"><i class="fas fa-square-check"></i></div><b>選択</b><span>ダウンロード</span></div>
+            <div class="arrow"><i class="fas fa-arrow-right"></i></div>
+            <div class="fnode"><div class="ic"><i class="fas fa-floppy-disk"></i></div><b>保存</b><span>端末に保存</span></div>
+          </div>
+
+          <div class="steps">
+            <!-- 1 -->
+            <article class="step">
+              <div class="step-txt">
+                <div class="step-head"><span class="step-num">1</span><h3 class="step-title">アルバムを開く（無料は購入不要）</h3><span class="screen-tag">お客様 / アルバム詳細</span></div>
+                <span class="role user"><i class="fas fa-mobile-screen"></i> お客様</span>
+                <p class="lead" style="margin-top:10px">メールのURL、またはホームのアルバムを開きます。</p>
+                <p><b>無料アルバムは購入手続きなし</b>で、そのままダウンロードできます。画面には閲覧期限（○月○日まで）が表示されます。</p>
+                <div class="action"><span class="tap">操作 →</span><span>「<b>選択する</b>」でダウンロードしたい写真を選ぶ</span></div>
+              </div>
+              <figure class="shot">
+                <div class="shot-frame"><div class="inner">
+                  <div class="shot-ph"><i class="fas fa-image"></i><b>12-user-album.png</b><span>お客様 / アルバム詳細</span></div>
+                  <img src="images/manual/12-user-album.png" alt="お客様 アルバム詳細" loading="lazy" onerror="this.remove()" />
+                  <span class="anno ring" style="--x:22%;--y:20%;--w:32%;--h:6%"></span>
+                </div></div>
+                <figcaption>無料アルバムは購入モーダルなしでDL可能</figcaption>
+              </figure>
+            </article>
+
+            <!-- 2 -->
+            <article class="step">
+              <div class="step-txt">
+                <div class="step-head"><span class="step-num">2</span><h3 class="step-title">写真を選んでダウンロード</h3><span class="screen-tag">お客様 / 選択モード</span></div>
+                <span class="role user"><i class="fas fa-mobile-screen"></i> お客様</span>
+                <p class="lead" style="margin-top:10px">写真をタップで選択（「すべて選択」も可）。「選択した写真をダウンロード」を押します。</p>
+                <ul>
+                  <li><b>1枚</b>：そのまま単体でダウンロード</li>
+                  <li><b>2枚以上</b>：まとめて<b>1つのZIPファイル</b>に</li>
+                  <li>1回あたり<b>最大120枚</b>。超える場合は数回に分ける</li>
+                </ul>
+              </div>
+              <figure class="shot">
+                <div class="shot-frame"><div class="inner">
+                  <div class="shot-ph"><i class="fas fa-image"></i><b>13-user-select.png</b><span>お客様 / 選択モード</span></div>
+                  <img src="images/manual/13-user-select.png" alt="お客様 写真選択モード" loading="lazy" onerror="this.remove()" />
+                  <span class="anno ring" style="--x:50%;--y:92%;--w:88%;--h:8%"></span>
+                </div></div>
+                <figcaption>最大120枚まで一度にダウンロード可能</figcaption>
+              </figure>
+            </article>
+
+            <!-- 3 -->
+            <article class="step">
+              <div class="step-txt">
+                <div class="step-head"><span class="step-num">3</span><h3 class="step-title">ZIP生成を待つ（複数枚のとき）</h3><span class="screen-tag">お客様 / 生成中</span></div>
+                <span class="role user"><i class="fas fa-mobile-screen"></i> お客様</span>
+                <p class="lead" style="margin-top:10px">複数枚のときは、サーバーでZIPを準備します。</p>
+                <p>「○枚のZIPを生成中…」のバナーが出ます。枚数により<b>数十秒〜数分</b>かかることがあります。この間も画面の閲覧は可能です。準備ができると自動でダウンロードが始まります。</p>
+              </div>
+              <figure class="shot">
+                <div class="shot-frame"><div class="inner">
+                  <div class="shot-ph"><i class="fas fa-image"></i><b>14-user-zip.png</b><span>お客様 / ZIP生成中</span></div>
+                  <img src="images/manual/14-user-zip.png" alt="お客様 ZIP生成中バナー" loading="lazy" onerror="this.remove()" />
+                  <span class="anno ring" style="--x:50%;--y:20%;--w:88%;--h:9%"></span>
+                </div></div>
+                <figcaption>生成完了後、自動でダウンロード開始</figcaption>
+              </figure>
+            </article>
+          </div>
+
+          <h3 style="margin:34px 0 4px;font-size:18px;font-weight:700">端末ごとの保存のされ方</h3>
+          <p style="margin:0 0 4px;color:var(--color-text-muted);font-size:14px">お客様の端末で、ダウンロードした写真がどこに入るか・どう見るかの案内です。</p>
+          <div class="devtable-wrap">
+            <table class="dev">
+              <thead>
+                <tr>
+                  <th>端末</th>
+                  <th>1枚のとき</th>
+                  <th>複数枚（ZIP）のとき</th>
+                  <th>写真の見方</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td><span class="os"><span class="oi"><i class="fas fa-desktop"></i></span>PC</span><br /><span class="pill">ブラウザ</span></td>
+                  <td><div class="where">ダウンロードフォルダ</div><div class="how">画像ファイルとして保存</div></td>
+                  <td><div class="where">ダウンロードフォルダ</div><div class="how">ZIPファイルが1つ保存される</div></td>
+                  <td><div class="how"><b>ZIPを右クリック →「すべて展開／解凍」</b>で写真を取り出す</div></td>
+                </tr>
+                <tr>
+                  <td><span class="os"><span class="oi"><i class="fab fa-apple"></i></span>iPhone</span><br /><span class="pill">Safari</span></td>
+                  <td><div class="where">「写真」または「ファイル」App</div><div class="how">保存先を選んで保存</div></td>
+                  <td><div class="where">「ファイル」App →「ダウンロード」</div><div class="how">ZIPが1つ保存される（複数DL確認は出ません）</div></td>
+                  <td><div class="how"><b>「ファイル」AppでZIPをタップ</b>すると解凍され、同じ場所にフォルダができる</div></td>
+                </tr>
+                <tr>
+                  <td><span class="os"><span class="oi"><i class="fab fa-android"></i></span>Android</span><br /><span class="pill">Chrome</span></td>
+                  <td><div class="where">「ダウンロード」フォルダ</div><div class="how">画像ファイルとして保存</div></td>
+                  <td><div class="where">「ダウンロード」フォルダ</div><div class="how">ZIPが1つ保存される</div></td>
+                  <td><div class="how"><b>「Files（ファイル）」アプリでZIPをタップ →「解凍」</b>で写真を取り出す</div></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <div class="note tip">
+            <div class="ni"><i class="fas fa-check"></i></div>
+            <div>
+              <h4>お客様への案内のコツ</h4>
+              <ul>
+                <li><b>複数枚は必ずZIP（圧縮ファイル）</b>で届きます。「解凍してから写真をご覧ください」と一言添えると親切です。</li>
+                <li>iPhoneのお客様が「写真アプリに見当たらない」と言ったら、<b>「ファイル」App の「ダウンロード」</b>を案内してください。</li>
+                <li>枚数が多いと生成に時間がかかります。<b>画面を閉じずに待つ</b>よう伝えてください。</li>
+              </ul>
+            </div>
+          </div>
+
+          <div class="note info">
+            <div class="ni"><i class="fas fa-life-ring"></i></div>
+            <div>
+              <h4>うまくいかないとき</h4>
+              <ul>
+                <li><b>ダウンロードが始まらない</b>：数秒おいて「選択した写真をダウンロード」をもう一度。連打はしない。</li>
+                <li><b>一部の写真が入っていない</b>：読み込めなかった写真は自動でスキップされ、画面から「もう一度試す／運営に問い合わせる」を選べます。</li>
+                <li><b>「最大120枚まで」表示</b>：選択を120枚以下に減らし、数回に分けてダウンロード。</li>
+                <li><b>期限切れ</b>：公開から30日を過ぎると閲覧・DLできません。期間内の案内を。</li>
+              </ul>
+            </div>
+          </div>
+        </section>
+      </div>
+    </main>
+
+    <footer>
+      <div class="container">
+        <div class="footer-content">
+          <div class="footer-main">
+            <div class="footer-logo">
+              <span class="logo-text">At Ima</span>
+              <span class="logo-sub">あっといま</span>
+            </div>
+            <p class="footer-description">
+              予約不要で呼べる出張カメラマンサービス<br />
+              思い立った瞬間に、家族の大切な時間を写真に残そう
+            </p>
+          </div>
+
+          <div class="footer-links">
+            <div class="footer-links-group">
+              <h4>サービス</h4>
+              <ul class="footer-links">
+                <li><a href="index.html#features">特徴</a></li>
+                <li><a href="index.html#how">使い方</a></li>
+                <li><a href="index.html#voices">利用者の声</a></li>
+              </ul>
+            </div>
+
+            <div class="footer-links-group">
+              <h4>参加する</h4>
+              <ul class="footer-links">
+                <li><a href="index.html#stakeholders">モニター応募</a></li>
+                <li><a href="index.html#stakeholders">カメラマン応募</a></li>
+                <li><a href="index.html#stakeholders">施設提携</a></li>
+              </ul>
+            </div>
+
+            <div class="footer-links-group">
+              <h4>お問い合わせ</h4>
+              <address class="footer-contact">
+                A-Tabiji合同会社<br />
+                <a href="mailto:info@atabiji.com">info@atabiji.com</a>
+              </address>
+            </div>
+          </div>
+        </div>
+
+        <div class="footer-bottom">
+          <p class="copyright">
+            &copy; <span id="current-year"></span> A-Tabiji合同会社 All Rights
+            Reserved.
+          </p>
+          <div class="footer-bottom-links">
+            <a href="privacy-policy.html">プライバシーポリシー</a>
+            <a href="terms-of-service.html">利用規約</a>
+            <a href="tokusho.html">特定商取引法に基づく表記</a>
+          </div>
+        </div>
+      </div>
+    </footer>
+
+    <script>
+      document.getElementById("current-year").textContent = new Date().getFullYear();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
撮影会当日のスタッフ向け操作マニュアルをHP掲載用ページ（`manual.html`）として追加します。

- **① 受付（無料アルバム作成）**: 無料トグル→QR→お客様のログイン/依頼→スタッフ自動遷移→**お客様端末で下に引っ張って更新→アルバム表示の確認**まで
- **② 写真格納・アルバム公開**: 追加→公開/保留の選別→公開＋メール通知
- **③ 写真ダウンロード**: 選択→ZIP→**PC/iPhone/Android別の保存方法**（表）
- 既存LPの `header/footer`・`css/style-amber.css` を流用。`css/manual.css` にページ固有スタイル、印刷CSS・レスポンシブ対応。
- 画面キャプチャは `images/manual/` に配置する方式（未配置時はファイル名プレースホルダ表示）。注釈は画像に焼かず**CSSオーバーレイ**なので差し替えても崩れない。

## 補足
- 実キャプチャは別途取得して `images/manual/` に配置予定（撮影スクリプトはアプリ側リポジトリで用意）。
- baseは `develop` にしています。LPの運用フローが異なる場合は付け替えてください。

## Test plan
- [x] `manual.html` をブラウザ表示：ライト/モバイル/印刷レイアウトを確認
- [ ] 実キャプチャ配置後に注釈位置（`.anno` の --x/--y/--w/--h）を微調整

🤖 Generated with [Claude Code](https://claude.com/claude-code)